### PR TITLE
Update warehouse SFT with system prompt

### DIFF
--- a/scripts/examples/reason1/spatial-ai-warehouse/configs/sft.toml
+++ b/scripts/examples/reason1/spatial-ai-warehouse/configs/sft.toml
@@ -1,6 +1,7 @@
 [custom.dataset]
 annotation_path = "<PATH_TO_DATASET>/train_llava.json"
 media_path = "<PATH_TO_DATASET>/"
+system_prompt = "Answer the questions."
 
 [custom.vision]
 fps = 1

--- a/scripts/examples/reason1/spatial-ai-warehouse/toolbox/custom_sft.py
+++ b/scripts/examples/reason1/spatial-ai-warehouse/toolbox/custom_sft.py
@@ -36,6 +36,8 @@ class CustomDatasetConfig(pydantic.BaseModel):
     """Dataset annotation path."""
     media_path: str = pydantic.Field(default="")
     """Dataset media path."""
+    system_prompt: str = pydantic.Field(default="")
+    """System prompt for post-training."""
 
 
 class CustomConfig(pydantic.BaseModel):
@@ -59,6 +61,7 @@ class CustomDataset(torch.utils.data.Dataset):
     ):
         self.annotation = json.load(open(custom_config.dataset.annotation_path))
         self.media_path = custom_config.dataset.media_path
+        self.system_prompt = custom_config.dataset.system_prompt
         self.config = config
         self.custom_config = custom_config
         self.vision_kwargs = custom_config.vision.model_dump(exclude_none=True)
@@ -88,6 +91,7 @@ class CustomDataset(torch.utils.data.Dataset):
         # Remove image and video tags from user prompt
         user_prompt = re.sub(r"(\n)?</?(image|video)>(\n)?", "", user_prompt)
         conversations = create_conversation(
+            system_prompt=self.system_prompt,
             user_prompt=user_prompt,
             response=response,
             images=images,

--- a/scripts/examples/reason1/spatial-ai-warehouse/toolbox/evaluate.py
+++ b/scripts/examples/reason1/spatial-ai-warehouse/toolbox/evaluate.py
@@ -46,6 +46,7 @@ DEFAULT_MAX_PIXELS = 655360
 DEFAULT_RESIZED_WIDTH = 960
 DEFAULT_RESIZED_HEIGHT = 540
 DEFAULT_MAX_TOKENS = 1024
+SYSTEM_PROMPT = "Answer the questions."
 
 
 def load_evaluation_data(
@@ -122,6 +123,7 @@ def process_single_task(
 
     # Create conversation without response (for evaluation)
     conversation = create_conversation(
+        system_prompt=SYSTEM_PROMPT,
         user_prompt=entry.get("user_prompt", ""),
         response="",  # No response for evaluation
         images=entry.get("images", []),


### PR DESCRIPTION
## Description

Add system prompt back for Warehouse SFT recipe

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)

## Changes Made

- [ ] Update `sft.toml` to support simple system prompt
- [ ] Update `custom_sft.py` to support additional system prompt
- [ ] Update `evaluate.py` accordingly

## Testing

- [ ] I have tested the changes locally on ORD cluster
- [ ] Documentation builds successfully
- [ ] Pre-commit hooks pass
- [ ] Examples run without errors for both data loading, training, and evaluation

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
NA


