### PR TITLE
add training data stats and remove redundant suffix

### DIFF
--- a/docs/recipes/post_training/reason1/intelligent-transportation/post_training.md
+++ b/docs/recipes/post_training/reason1/intelligent-transportation/post_training.md
@@ -32,7 +32,7 @@ Here are examples of the video clips and textual descriptions of the pedestrian 
 
 <br>
 
-For this experiment, we fine-tune the Cosmos Reason 1 model on the Environment VQA subset of the WTS dataset.
+For this experiment, we fine-tune the Cosmos Reason 1 model on the Environment VQA subset of the WTS dataset. The subset contains 341 videos with 5k MCQ question-answer pairs. The average video length is about 75 seconds.
 
 ### Data Pre-processing
 
@@ -49,7 +49,7 @@ python data_preprocess.py --data_path /path/to/WTS/folder
 
 ## Post-Training with Supervised Fine-Tuning (SFT)
 
-After preprocessing, the WTS dataset is in Llava format and ready for training. To launch training, we follow the default cosmos-rl training command in [Cosmos Reason 1 Post-Training Llava Example](https://github.com/nvidia-cosmos/cosmos-reason1/tree/main/examples/post_training_llava) with a small modification to add system prompt and an MCQ prompt suffix in `custom_sft.py` script:
+After preprocessing, the WTS dataset is in Llava format and ready for training. To launch training, we follow the default cosmos-rl training command in [Cosmos Reason 1 Post-Training Llava Example](https://github.com/nvidia-cosmos/cosmos-reason1/tree/main/examples/post_training_llava):
 
 ```shell
 # From scripts/examples/reason1/intelligent-transportation directory

--- a/scripts/examples/reason1/intelligent-transportation/custom_sft.py
+++ b/scripts/examples/reason1/intelligent-transportation/custom_sft.py
@@ -30,8 +30,6 @@ from cosmos_reason1_utils.text import create_conversation
 from cosmos_reason1_utils.vision import VisionConfig
 from cosmos_rl.utils.logging import logger
 
-MCQ_PROMPT_SUFFIX = "\nAnswer with the option's letter from the given choices directly."
-
 
 class CustomDatasetConfig(pydantic.BaseModel):
     annotation_path: str = pydantic.Field()
@@ -39,12 +37,10 @@ class CustomDatasetConfig(pydantic.BaseModel):
     media_path: str = pydantic.Field(default="")
     """Dataset media path."""
     system_prompt: str = pydantic.Field(default="")
-    """System prompt."""
+    """System prompt for post-training."""
 
 
 class CustomConfig(pydantic.BaseModel):
-    """Custom config."""
-
     dataset: CustomDatasetConfig = pydantic.Field()
     """Dataset config."""
 
@@ -58,15 +54,12 @@ class CustomConfig(pydantic.BaseModel):
 
 
 class CustomDataset(torch.utils.data.Dataset):
-    """Custom dataset."""
-
     def __init__(
         self,
         config: cosmos_rl.policy.config.Config,
         custom_config: CustomConfig,
     ):
-        with open(custom_config.dataset.annotation_path, "r") as f:
-            self.annotation = json.load(f)
+        self.annotation = json.load(open(custom_config.dataset.annotation_path))
         self.media_path = custom_config.dataset.media_path
         self.system_prompt = custom_config.dataset.system_prompt
         self.config = config
@@ -97,7 +90,6 @@ class CustomDataset(torch.utils.data.Dataset):
 
         # Remove image and video tags from user prompt
         user_prompt = re.sub(r"(\n)?</?(image|video)>(\n)?", "", user_prompt)
-        user_prompt = user_prompt + MCQ_PROMPT_SUFFIX
 
         conversations = create_conversation(
             system_prompt=self.system_prompt,

--- a/scripts/examples/reason1/intelligent-transportation/evaluate.py
+++ b/scripts/examples/reason1/intelligent-transportation/evaluate.py
@@ -58,8 +58,6 @@ from utils.output import (
     save_results_parallel,
 )
 
-MCQ_PROMPT_SUFFIX = "\nAnswer with the option's letter from the given choices directly."
-
 
 @attrs.define(slots=False)
 class LlavaInputStructure:
@@ -415,7 +413,6 @@ def make_all_tasks(
                     "",
                     item["conversations"][0]["value"],
                 ).strip()
-                question += MCQ_PROMPT_SUFFIX
                 conversation = [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": question},


### PR DESCRIPTION
Updated to reason1/intelligent-transportation:
- Added training data statistics to the documentation
- Removed redundant MCQ suffix that is added in `data_preprocess.py`