### PR TITLE
fix eval config in reason1 its examples

### DIFF
--- a/scripts/examples/reason1/intelligent-transportation/eval_config.yaml
+++ b/scripts/examples/reason1/intelligent-transportation/eval_config.yaml
@@ -45,7 +45,7 @@ vision:
   # Downsample video frame rate
   fps: 1
   # video or image resolution
-  total_pixels: 81920
+  max_pixels: 81920
 # Generation parameters
 generation:
   # Maximum number of retries for failed generations


### PR DESCRIPTION
fix the eval config from `total_pixels` to `max_pixels` in `eval_config.yaml`