### PR TITLE
Add carousel GIF to overview page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/.pre-commit-config-base.yaml
+++ b/.pre-commit-config-base.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-added-large-files
         args: ['--maxkb=10000'] # 10MB
+        exclude: ^docs/assets/images/carousel\.gif$
       - id: forbid-submodules
       - id: detect-private-key
       - id: detect-aws-credentials

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+        exclude: ^docs/assets/images/carousel\.gif$
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable

--- a/docs/assets/images/carousel.gif
+++ b/docs/assets/images/carousel.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307dfe7e84367c4d8cc34c01c72518de07e90b2d07fa86447a1b3b6950648c0c
+size 144066326

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Cosmos Cookbook
 
+![Carousel](assets/images/carousel.gif)
+
 ## Overview
 
 **[NVIDIA Cosmos™](https://www.nvidia.com/en-us/ai/cosmos/)** is a platform of state-of-the-art generative world foundation models (WFMs), guardrails, and an accelerated data processing and curation pipeline. This cookbook serves as a practical guide to the Cosmos open models — offering step-by-step workflows, technical recipes, and concrete examples for building, adapting, and deploying WFMs. It helps developers reproduce successful Cosmos model deployments and customize them for their specific domains.


### PR DESCRIPTION
## Summary
Adds a carousel GIF to the Cosmos Cookbook overview page, displayed prominently below the main title.

Connected to [Issues 41](https://github.com/nvidia-cosmos/cosmos-cookbook/issues/41)

## Changes
- **Added** `carousel.gif` to `docs/assets/images/`
- **Updated** `docs/index.md` to display the carousel GIF below the "Cosmos Cookbook" title
- **Updated** pre-commit configuration files to exclude `carousel.gif` from large file size checks
- **Configured** Git LFS to track GIF files for efficient handling of large assets

## Technical Details
- The carousel GIF is stored using Git LFS due to its size (137MB)
- Pre-commit hooks updated to allow the large GIF file
- Image is positioned between the main title and the "Overview" section