### PR TITLE
Fix missing video tag in physical plausibility check recipe

### DIFF
--- a/docs/recipes/post_training/reason1/physical-plausibility-check/post_training.md
+++ b/docs/recipes/post_training/reason1/physical-plausibility-check/post_training.md
@@ -118,7 +118,9 @@ The following examples demonstrate zero-shot predictions from the Cosmos Reason 
 
 #### Car Crashes into Stack of Cardboard Boxes
 
-<source src="https://videophysics2testvideos.s3.us-east-2.amazonaws.com/hunyuan_xdit/A_car_crashes_into_a_stack_of_cardboard_boxes,_sending_the_boxes_flying_in_all_directions.mp4" type="video/mp4">
+<video controls width="480">
+  <source src="https://videophysics2testvideos.s3.us-east-2.amazonaws.com/hunyuan_xdit/A_car_crashes_into_a_stack_of_cardboard_boxes,_sending_the_boxes_flying_in_all_directions.mp4" type="video/mp4">
+</video>
 
 - **Model prediction**: 1
 - **Ground truth**: 2 (poor adherence to physical laws)


### PR DESCRIPTION
## Description

A video tag was removed in a previous commit and the video disappeared. Revert that change to fix the issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- [x] Added/updated documentation
- [ ] Added/updated examples
- [ ] Fixed bugs or issues
- [ ] Improved code quality
- [ ] Updated dependencies

## Testing

- [x] I have tested the changes locally
- [x] Documentation builds successfully
- [x] Pre-commit hooks pass
- [ ] Examples run without errors
- [x] Links and references are valid

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Any additional information that reviewers should know.
