### PR TITLE
Fix sub bullet indentation for Getting started with Brev T25

### DIFF
--- a/docs/getting_started/transfer_and_predict_on_brev.md
+++ b/docs/getting_started/transfer_and_predict_on_brev.md
@@ -124,7 +124,9 @@ chmod +x $HOME/run_transfer2.5_docker.sh
 - Note Brev's deployment time estimate when evaluating instance types, ex: "Ready in 7minutes".
 - Deployment can fail on occasion and the driver version might not be what you expect when trying a new provider. For these reasons, set aside 3 times the estimated ready time in your mind and you will be happy 😀
 - Your favorite cloud provider might not always be available.
-- You can change a Launchable's compute! Reasons you might want to include
-    - ☁️ The preferred cloud provider is not available
-    - 💰 You want to save money with a different configuration
-    - 🏎️ You want to try higher specs
+- You can change a Launchable's compute! Reasons you might want to include:
+  <ul>
+    <li>☁️ The preferred cloud provider is not available</li>
+    <li>💰 You want to save money with a different configuration</li>
+    <li>🏎️ You want to try higher specs</li>
+  </ul>


### PR DESCRIPTION
Indentation of sub bullets for Tips section describing when you might want to change the compute config was incorrect such that the sub bullets were at the same indentation level as the major bullets. 

Fix: use inline HTML 

#### Why not indent 4 spaces to get nested indent?
* markdownlint expects 2-space indentation for nested lists (MD007 default)
* Python-Markdown requires 4-space indentation to render nested lists in HTML
* 2-space indentation was creating separate list items instead of nested ones