### PR TITLE
Add Adobe Launch scripts to documentation site by creating main.html

### DIFF
--- a/docs/assets/overrides/main.html
+++ b/docs/assets/overrides/main.html
@@ -9,5 +9,9 @@
 {% block scripts %}
   {{ super() }}
   {# Adobe Launch Footer Script #}
-  <script type="text/javascript">_satellite.pageBottom();</script>
+  <script type="text/javascript">
+    if (window._satellite) {
+      _satellite.pageBottom();
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
Add Adobe Launch scripts to documentation site

Integrates Adobe Launch analytics scripts:
- Header script in `<head>` tag
- Footer script before `</body>` tag

Implemented via Material theme template override (`main.html`).

Please help with verification. 

Steps to check: 
	1.	Open the site in Chrome where Adobe tracking should be active.
	2.	Right-click anywhere on the page → select Inspect.
	3.	In DevTools, go to the Application (or Storage) tab.
	4.	Under Storage → Cookies, click the site URL (e.g. https://google.com).
	5.	In the cookie list, use the filter/search box to look for the Adobe cookie name (e.g. AMCV_…, s_ecid, etc.).
	6.	Confirm that:
	•	The cookie exists,
	•	The Domain matches the site, and
	•	The cookie is not expired (check Expires/Max-Age).