### PR TITLE
Reapply "OneTrust + Adobe Integration"

### DIFF
--- a/docs/assets/overrides/main.html
+++ b/docs/assets/overrides/main.html
@@ -5,7 +5,7 @@
 <!-- Adobe Launch is intentionally loaded only after analytics consent (OneTrust C0002). -->
 <!-- OneTrust Cookies Consent Notice start for nvidia.com -->
 <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true"
-    type="text/javascript" charset="UTF-8" data-domain-script="3e2b62ff-7ae7-4ac5-87c8-d5949ecafff5"></script>
+    type="text/javascript" charset="UTF-8" data-domain-script="3e2b62ff-7ae7-4ac5-87c8-d5949ecafff5-test"></script>
 <script type="text/javascript">
     // Adobe Launch source (loaded dynamically once analytics consent is granted).
     var ADOBE_LAUNCH_SRC = 'https://assets.adobedtm.com/5d4962a43b79/814eb6e9b4e1/launch-4bc07f1e0b0b.min.js';


### PR DESCRIPTION
## Description

In #127 we merged a change to add a cookie notification banner.  We reverted this change in #134 because the banner could not be dismissed.

Based on docs at https://my.onetrust.com/s/article/UUID-7478d3b4-18eb-3ac0-a6fd-fb7ebff9f8dc?language=en_US the cookie notification banner is linked to a particular domain, and for sites other than nvidia.com we need to use the `-test` script instead of the production script.  This approach works on sites like https://nvdla.org/.

This PR reapplies #127 using the "-test" config, which will be specific to https://nvidia-cosmos.github.io/ but should otherwise meet our needs (i.e.: showing the right banner and storing user preferences).