### PR TITLE
Add onetrust and adobe launch scripts

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Setup just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
       - name: Build documentation
+        env:
+          # Forks use test cookie script
+          COOKIE_TEST_MODE: ${{ github.repository != 'nvidia-cosmos/cosmos-cookbook' }}
         run: |
           just ci-deploy-external
       - name: Upload artifact

--- a/docs/assets/overrides/main.html
+++ b/docs/assets/overrides/main.html
@@ -4,7 +4,7 @@
 {{ super() }}
 <!-- OneTrust Cookies Consent Notice start for nvidia-cosmos.github.io -->
 
-<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="019c0510-0233-7bb8-be91-9083a1e91694" ></script>
+<script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" data-document-language="true" type="text/javascript" charset="UTF-8" data-domain-script="019c0510-0233-7bb8-be91-9083a1e91694{% if config.extra.cookie_test_mode %}-test{% endif %}" ></script>
 <script type="text/javascript">
 function OptanonWrapper() {
         var event = new Event('bannerLoaded');

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ _template *args:
 # Serve the internal documentation locally
 serve-internal:
   just _template -d internal.yaml
-  uv run mkdocs serve
+  uv run mkdocs serve -f mkdocs-internal.yml
 
 # Serve the external documentation locally
 serve-external:
@@ -33,7 +33,7 @@ lint: setup
 test: lint
   # Test the internal documentation
   just _template -d internal.yaml
-  uv run mkdocs build --strict
+  uv run mkdocs build -f mkdocs-internal.yml --strict
 
   # Test the external documentation
   just _template -d external.yaml
@@ -48,12 +48,13 @@ ci-lint:
 ci-deploy-internal:
   rm -rf public
   just _template -d internal.yaml
-  uv run mkdocs build --site-dir public --strict
+  uv run mkdocs build -f mkdocs-internal.yml --site-dir public --strict
 
 # CI: Deploy the external documentation
+# Set COOKIE_TEST_MODE=true to use test cookie script (for forks)
 ci-deploy-external:
   rm -rf external
   just _template -d external.yaml
-  uv run mkdocs build --site-dir external/site --strict
+  uv run mkdocs build {{ if env("COOKIE_TEST_MODE", "") == "true" { "-f mkdocs-internal.yml" } else { "" } }} --site-dir external/site --strict
   mkdir -p external/cosmos-cookbook
   cp -r scripts external/cosmos-cookbook/scripts

--- a/mkdocs-internal.yml
+++ b/mkdocs-internal.yml
@@ -1,0 +1,3 @@
+INHERIT: mkdocs.yml
+extra:
+  cookie_test_mode: true


### PR DESCRIPTION
## Description

This MR adds two scripts to the base mkdocs template:

* OneTrust
* AdobeLaunch

The "extrahead" and "scripts" blocks seem like reasonable places to add these hooks based on the documentation at https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks


```
extrahead	Empty block to add custom meta tags
scripts	Wraps the JavaScript application (footer)
```

The generated HTML also looks correct (it puts the scripts at the end of the header and the end of the body).

I deployed this PR to:

https://d2b4.github.io/cosmos-cookbook/

which is using the `-test` version of the script.

You can test what it looks like on first visit by visiting the page in Incognito mode.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- [ ] Added/updated documentation
- [ ] Added/updated examples
- [ ] Fixed bugs or issues
- [ ] Improved code quality
- [ ] Updated dependencies

## Testing

- [x] I have tested the changes locally
- [x] Documentation builds successfully
- [x] Pre-commit hooks pass
- [ ] Examples run without errors
- [ ] Links and references are valid

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

Any additional information that reviewers should know.
