### PR TITLE
feat(byo-video): /byo-video skill — multi-backend Cosmos VLM deploy

### DIFF
--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -1,0 +1,54 @@
+# Cosmos Cookbook Skills
+
+`.claude/` contains agent skills usable by cosmos-cookbook contributors. The
+`/byo-video` skill in `commands/byo-video.md` walks a contributor through
+deploying a Cosmos VLM to a Gradio web UI on their own GPU — it handles
+environment validation, model selection, container launch, and the web UI
+wiring so a contributor can go from a fresh GPU box to a working
+"bring-your-own-video" demo without leaving the chat.
+
+## Quick Reference
+
+| Command | What It Does | When to Use |
+|---------|-------------|-------------|
+| `/byo-video` | Deploy a Cosmos VLM to a local Gradio web UI on your own GPU | Standing up a self-hosted video understanding demo |
+
+---
+
+## `/byo-video`
+
+**Purpose:** Walk a contributor through deploying a Cosmos VLM to a Gradio web
+UI on a GPU they control. The skill validates the environment, selects a
+compatible model, launches the inference container, and wires up the web UI so
+the contributor can upload a video and see model output in a browser.
+
+**Human usage:**
+```
+/byo-video
+```
+Run this on a host with an NVIDIA GPU. The skill will check prerequisites,
+guide model selection, start the inference backend, and open the Gradio UI.
+
+**Agent usage:** Invoke when the user wants a self-hosted Cosmos VLM demo with
+a web frontend. The skill is interactive — it expects to ask the user about
+model choice and confirm long-running steps.
+
+**Flow:**
+1. Validate GPU, drivers, container runtime, and disk space
+2. Offer a list of compatible Cosmos VLMs and let the user pick one
+3. Pull and launch the inference container
+4. Start the Gradio web UI and surface the local URL
+5. Hand off to the user for interactive video uploads and prompts
+
+See `commands/byo-video.md` for the full skill definition and step-by-step
+agent guidance.
+
+---
+
+## How Agents Discover and Use These Skills
+
+Claude Code automatically reads `CLAUDE.md` files in the working directory and
+its subdirectories. When a session starts in the cosmos-cookbook repo root,
+the `.claude/commands/` directory makes the slash commands above available to
+the agent, and any per-recipe `CLAUDE.md` is loaded when the user navigates
+into a recipe directory.

--- a/.claude/commands/byo-video.md
+++ b/.claude/commands/byo-video.md
@@ -1,0 +1,1392 @@
+# /byo-video — Cosmos BYO-Video Demo
+
+**Single-model deployment skill.** Deploys any supported model (Cosmos Reason2, Nemotron-Nano-12B-v2-VL, Qwen3-VL, etc.) to a Gradio web UI at a `gradio.live` public URL — user uploads video in browser.
+
+For multi-model side-by-side comparison, use `/vlm-race` (separate skill, separate instance required).
+
+Default output: **Gradio web UI at a `gradio.live` public URL** — user uploads video in browser.
+
+**Canonical scripts (stable, versioned — do not read from /tmp/):**
+- `~/.claude/scripts/gradio_cr2_byo.py`  — Gradio app (all supported models)
+- `~/.claude/scripts/byo_video_setup.py` — Bootstrap + launch script
+
+---
+
+**Primary launch command (all environments):**
+```bash
+python3 /tmp/byo_video_setup.py
+```
+This script shows live step-by-step progress with ETAs for every install stage, then prints a clickable hyperlink to the Gradio UI. The URL is also written to `/tmp/gradio_url.txt` for agent capture. Deploy it to the instance before running (see deploy section below).
+
+---
+
+## SKILL PROTOCOL — Hybrid: main session + observer
+
+The main session owns **PHASE 0–1** (pre-checks + picker). These phases are interactive;
+`AskUserQuestion` resolves all user decisions before anything runs on a GPU.
+
+Immediately after the picker answers are resolved, the main session spawns a **background
+observer** for **PHASE 2–6** (provision → shell ready → deploy scripts → setup → Gradio live).
+The observer handles all long-running work autonomously, keeping the main session free for
+conversation. On completion the observer writes `/tmp/byo_video_observer_result.json`; the
+main session reads it via the task completion notification and either displays the final URL
+panel or fires `AskUserQuestion` for recovery.
+
+**All user decisions happen in PHASE 1 before the observer spawns.** This includes the
+"restart stopped instance vs provision fresh" choice — PHASE 0 data is used to build the Q3
+options dynamically (see PICKER section).
+
+**Never use external chat or notification systems in this skill.** All user communication
+happens in the Claude Code UI — panels, `AskUserQuestion`, and completion text.
+
+### PHASE 0 — Pre-checks
+
+0. **Clear stale session artifacts first** (one Bash call before anything else):
+   ```bash
+   rm -f /tmp/byo_video_observer_result.json /tmp/byo_video_progress.json
+   ```
+   These files persist across Claude Code sessions. If not cleared, the progress cron will
+   read a prior session's result and report a false success or failure. This step is mandatory
+   and must run before `brev ls`.
+
+1. Run `brev ls` via Bash. Capture the full output.
+2. Note stopped H100/H200 instances — these become options in the PHASE 1 picker (Q3).
+3. Note any RUNNING instances (may be reusable).
+
+Display initial panel:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  Cosmos BYO-Video  ·  Pre-checks                             ║
+╠══════════════════════════════════════════════════════════════╣
+║  Existing instances:                                         ║
+║    [list each: name | status | GPU | type]                   ║
+║    (or "None found")                                         ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+### PHASE 1 — Picker
+
+Load `AskUserQuestion` via ToolSearch: `query: "select:AskUserQuestion"`, then fire all 3
+questions in a single call (see PICKER section below for the full call).
+
+**Q3 always offers four options.** The first slot is dynamic; the remaining three are fixed:
+
+- **Slot 1 (dynamic):** If PHASE 0 found exactly one stopped instance with a compatible GPU for
+  the selected model, use: `{ label: "Restart <name> (<GPU>)", description: "Resume stopped — faster to SHELL READY" }`
+  mapping to `DEPLOY_TARGET=brev:<name>`. If multiple stopped instances match, pick the one
+  whose GPU tier best fits MODEL_SIZE (prefer H200 for 32B/C3-32B, H100 for all others).
+  If no stopped instances match, use `{ label: "New Brev instance", description: "Agent provisions appropriate GPU tier" }`.
+- **Slot 2 (fixed):** `{ label: "New Brev instance", description: "Agent provisions appropriate GPU tier for your model" }` — always present unless Slot 1 is already "New Brev".
+- **Slot 3 (fixed):** `{ label: "SSH target", description: "Provide user@host or IP — any GPU machine you can SSH into" }` → follow-up AskUserQuestion for host.
+- **Slot 4 (fixed):** `{ label: "Local machine", description: "Run on this Mac — agent checks nvidia-smi locally first" }` → `DEPLOY_TARGET=local`.
+
+This ensures SSH and Local are always reachable regardless of how many Brev instances exist.
+
+Once all answers are received, resolve `MODEL_ID`, `MODEL_SIZE`, `INFERENCE_BACKEND`,
+`DEPLOY_TARGET` per the answer→env var mapping table.
+
+If Q3 answer is "Existing Brev" or "SSH target", fire one follow-up `AskUserQuestion` to collect
+the instance name or host.
+
+Record `PROVISION_START_TS` immediately after all answers are in. Then spawn the observer
+(see HANDOFF section) and stay available for conversation.
+
+---
+
+## PICKER — Main session PHASE 1
+
+Run after PHASE 0. Load `AskUserQuestion` via ToolSearch first: `query: "select:AskUserQuestion"`
+
+Then fire with all 3 questions in a single call:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "Backend?",
+      header: "Backend",
+      multiSelect: false,
+      options: [
+        { label: "vLLM (Recommended)", description: "~15–20 min setup, quantization support, fast inference" },
+        { label: "HF Transformers", description: "~8–12 min setup, no quantization, simpler" },
+        { label: "NIM (local Docker)", description: "Pull nvcr.io NIM container, serve OpenAI-compatible API on port 8000 — needs NGC_API_KEY + Docker on the target" }
+      ]
+    },
+    {
+      question: "Model?",
+      header: "Model",
+      multiSelect: false,
+      options: [
+        { label: "Cosmos Reason2 2B", description: "nvidia/Cosmos-Reason2-2B (public, ≥40GB VRAM)" },
+        { label: "Cosmos Reason2 8B", description: "nvidia/Cosmos-Reason2-8B (public, ≥80GB VRAM)" },
+        { label: "Cosmos Reason2 32B", description: "nvidia/Cosmos-Reason2-32B (public, ≥141GB VRAM — H200 required)" },
+        { label: "Something else", description: "Cosmos 3 (private), Cosmos Transfer, Nemotron, non-NVIDIA models" }
+      ]
+    },
+    {
+      question: "Environment?",
+      header: "Environment",
+      multiSelect: false,
+      options: [
+        // Slot 1: best stopped Brev instance for selected model, OR "New Brev instance" if none
+        { label: "Restart <name> (<GPU>)", description: "Resume stopped instance — faster to SHELL READY" },
+        // OR if no stopped instance matches:
+        // { label: "New Brev instance", description: "Agent provisions appropriate GPU tier for your model" },
+
+        // Slot 2: always present (unless Slot 1 is already "New Brev instance")
+        { label: "New Brev instance", description: "Agent provisions appropriate GPU tier for your model" },
+
+        // Slots 3 & 4: always present — never omit these
+        { label: "SSH target", description: "Provide user@host or IP — any GPU machine you can SSH into" },
+        { label: "Local machine", description: "Run on this Mac — agent checks nvidia-smi locally" }
+      ]
+    }
+  ]
+})
+```
+
+**Answer → env var mapping:**
+
+| Question | Answer | Sets |
+|---|---|---|
+| Q1 Backend | vLLM | `INFERENCE_BACKEND=vllm` |
+| Q1 Backend | HF Transformers | `INFERENCE_BACKEND=hf` |
+| Q1 Backend | NIM (local Docker) | `INFERENCE_BACKEND=nim_local` · `NIM_IMAGE=nvcr.io/nim/nvidia/<model-short-id>:latest` (resolved from MODEL_ID) · requires `NGC_API_KEY` |
+| Q2 Model | Cosmos Reason2 2B | `MODEL_ID=nvidia/Cosmos-Reason2-2B` · `MODEL_SIZE=2B` |
+| Q2 Model | Cosmos Reason2 8B | `MODEL_ID=nvidia/Cosmos-Reason2-8B` · `MODEL_SIZE=8B` |
+| Q2 Model | Cosmos Reason2 32B | `MODEL_ID=nvidia/Cosmos-Reason2-32B` · `MODEL_SIZE=32B` |
+| Q2 Model | Something else | Fire SOMETHING ELSE sub-picker (see below) |
+| Q3 Env | New Brev instance | `DEPLOY_TARGET=brev:new` |
+| Q3 Env | Existing Brev | Follow-up AskUserQuestion: "Instance name?" → `DEPLOY_TARGET=brev:<name>` |
+| Q3 Env | SSH target | Follow-up AskUserQuestion: "user@host or IP?" → `DEPLOY_TARGET=ssh:<user@host>` |
+| Q3 Env | Local machine | `DEPLOY_TARGET=local` |
+
+**SOMETHING ELSE sub-picker** — fire immediately when user selects "Something else" for Q2:
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which model?",
+      header: "Model",
+      multiSelect: false,
+      options: [
+        { label: "Cosmos3-Nano-Reasoner", description: "nvidia/Cosmos3-Nano-Reasoner (8B, private, ≥40GB VRAM, HF_TOKEN required)" },
+        { label: "Cosmos3-Reasoner-32B", description: "nvidia/Cosmos3-Reasoner-32B (32B, gated, nvidia org + HF_TOKEN required)" },
+        { label: "Cosmos Transfer 2.5", description: "nvidia/Cosmos-Transfer2.5 (generation model, ≥80GB VRAM)" },
+        { label: "Nemotron-Nano-12B-v2-VL", description: "nvidia/Nemotron-Nano-12B-v2-VL-BF16 (12B, gated, vLLM only, ≥40GB VRAM)" },
+        { label: "Non-NVIDIA models", description: "Best-effort only, not officially supported" }
+      ]
+    }
+  ]
+})
+```
+
+| Selection | Sets |
+|---|---|
+| Cosmos3-Nano-Reasoner | `MODEL_ID=nvidia/Cosmos3-Nano-Reasoner` · `MODEL_SIZE=C3-8B` |
+| Cosmos3-Reasoner-32B | `MODEL_ID=nvidia/Cosmos3-Reasoner-32B` · `MODEL_SIZE=C3-32B` |
+| Cosmos Transfer 2.5 | `MODEL_ID=nvidia/Cosmos-Transfer2.5` · `MODEL_SIZE=32B` |
+| Nemotron-Nano-12B-v2-VL | `MODEL_ID=nvidia/Nemotron-Nano-12B-v2-VL-BF16` · `MODEL_SIZE=NEM-12B` |
+| Non-NVIDIA models | Show disclaimer inline, then fire Qwen sub-picker |
+
+**Non-NVIDIA disclaimer (display inline before sub-picker):**
+> ⚠️ Non-NVIDIA models: NVIDIA does not officially support or guarantee setup for third-party models. This is best-effort only.
+
+**Qwen sub-picker:**
+
+```
+AskUserQuestion({
+  questions: [
+    {
+      question: "Which non-NVIDIA model?",
+      header: "Model",
+      multiSelect: false,
+      options: [
+        { label: "Qwen3-VL-2B-Instruct", description: "Qwen/Qwen3-VL-2B-Instruct (public, ~8GB VRAM)" },
+        { label: "Qwen3-VL-8B-Instruct", description: "Qwen/Qwen3-VL-8B-Instruct (public, ~20GB VRAM)" },
+        { label: "Qwen3-VL-32B-Instruct", description: "Qwen/Qwen3-VL-32B-Instruct (public, ~64GB VRAM)" }
+      ]
+    }
+  ]
+})
+```
+
+| Selection | Sets |
+|---|---|
+| Qwen3-VL-2B-Instruct | `MODEL_ID=Qwen/Qwen3-VL-2B-Instruct` · `MODEL_SIZE=QW3-2B` |
+| Qwen3-VL-8B-Instruct | `MODEL_ID=Qwen/Qwen3-VL-8B-Instruct` · `MODEL_SIZE=QW3-8B` |
+| Qwen3-VL-32B-Instruct | `MODEL_ID=Qwen/Qwen3-VL-32B-Instruct` · `MODEL_SIZE=QW3-32B` |
+
+Once `MODEL_ID`, `MODEL_SIZE`, `INFERENCE_BACKEND`, `DEPLOY_TARGET` are all resolved: record
+`PROVISION_START_TS` and spawn the observer (see HANDOFF section below).
+
+---
+
+## EXECUTION PROTOCOL — Phase 1 (main session) + Phases 2–6 (observer)
+
+The main session executes only PHASE 0–1. After the picker resolves all answers it spawns the
+observer and stays free for conversation.
+
+**PROVISION_START_TS** is recorded in PHASE 1 immediately after all picker answers are in and
+passed to the observer as part of the spawn prompt.
+
+The observer handles PHASE 2–6. It outputs clean checklist panels — commands run silently
+underneath. See **OBSERVER PROTOCOL** section for the observer's checklist format and
+per-phase instructions.
+
+---
+
+### HANDOFF — Spawn observer after PHASE 1
+
+After all picker answers are resolved, display a brief handoff message and spawn the observer:
+
+```
+Setting up your demo — observer is running in the background (~15–20 min).
+I'll show you the Gradio URL when it's live. Feel free to keep chatting.
+```
+
+Spawn:
+
+```
+Agent({
+  subagent_type: "general-purpose",
+  run_in_background: True,
+  name: "byo-video-observer",
+  prompt: """
+OBSERVER TASK — Cosmos BYO-Video PHASE 2–6
+
+You are a background observer. Read the full OBSERVER PROTOCOL section of the /byo-video
+skill. Execute PHASE 2 through PHASE 6 exactly as described there.
+
+Inherited state (fill in actual values):
+  DEPLOY_TARGET:       <brev:new | brev:<name> | ssh:<user@host> | local>
+  MODEL_ID:            <model_id>
+  MODEL_SIZE:          <model_size>
+  INFERENCE_BACKEND:   <backend>
+  RATE:                <rate_per_hour>
+  PROVISION_START_TS:  <epoch_seconds>
+
+On success write to /tmp/byo_video_observer_result.json on the LOCAL machine:
+  {"status":"live","url":"<gradio_url>","elapsed_s":<N>,"cost":<N>,"instance":"<name>","rate":<rate>,"gpu":"<gpu_label>","model_id":"<model_id>","model_size":"<model_size>","backend":"<backend>"}
+
+On unrecoverable failure write:
+  {"status":"failed","phase":<N>,"error":"<one-line error>","instance":"<name>"}
+
+Then exit.
+"""
+})
+```
+
+**After spawning the observer, immediately start the progress loop:**
+
+Load `CronCreate` via ToolSearch: `query: "select:CronCreate"`, then create:
+
+```
+CronCreate({
+  cron: "*/1 * * * *",
+  prompt: "Check /byo-video observer progress: read /tmp/byo_video_progress.json and /tmp/byo_video_observer_result.json on the local machine; display a one-line status update with the current checklist phase and elapsed time. If result JSON exists with status='live', display the LIVE final panel and cancel this cron job (load CronDelete via ToolSearch first). If result JSON exists with status='failed', fire AskUserQuestion with recovery options (see HALT-AND-ASK) and cancel this cron job.",
+  recurring: true
+})
+```
+
+Store the returned job ID as `PROGRESS_LOOP_ID`. Cancel it with `CronDelete(PROGRESS_LOOP_ID)` when the observer completes (success or failure).
+
+After spawning: stay available for conversation.
+When the task completion notification fires, OR when the progress loop detects a result JSON, read `/tmp/byo_video_observer_result.json`:
+- `status == "live"` → display the LIVE final panel (see PHASE 6 completion template). Cancel the progress loop.
+- `status == "failed"` → fire `AskUserQuestion` with recovery options (see HALT-AND-ASK). Cancel the progress loop.
+
+---
+
+### OBSERVER PROTOCOL — Standing Rule
+
+> **OBSERVER RULE: No silent exits.**
+> On ANY unrecoverable error — SSH failure, brev create failure, vLLM error, setup script error, all providers exhausted — the observer MUST:
+> 1. Write `/tmp/byo_video_observer_result.json` on the local machine with `{"status":"failed","phase":<N>,"error":"<one-line>","instance":"<name>"}`.
+> 2. Then `exit`.
+>
+> Never exit without writing this file. The main session's progress loop reads it every minute — an absent file means "still running," so a silent exit leaves the user waiting forever.
+
+---
+
+### OBSERVER PROTOCOL — PHASE 2: PROVISION
+
+**This phase and all subsequent phases run inside the observer. Do not prompt the user.**
+
+**HF_TOKEN:** Auto-read by the setup script from `~/.cache/huggingface/token` on the remote
+instance. Do NOT ask. Do NOT pass as a CLI arg.
+
+**For `DEPLOY_TARGET=brev:new`:**
+1. Look up MODEL_SIZE in MODEL_GPU_REQUIREMENTS to select provider type.
+2. Run `brev create <name> --type <provider_type>` — one Bash call.
+   Name convention: `cr2-<modelsize>-<timestamp-short>` (e.g., `cr2-2b-0505`)
+3. `brev create` blocks until shell ready. Proceed to PHASE 4.
+
+**CRITICAL — `cloudCredId` error halt:** If `brev create` output contains `cloudCredId or workspaceGroupId must be specified on request`, do NOT rotate to a fallback provider — this error is an org-level credential gap that applies to all provider types. Write failure JSON immediately and exit:
+`{"status":"failed","phase":2,"error":"Brev org missing cloud credential — brev create blocked for all providers. Fix in Brev dashboard org settings.","instance":"<name>"}`
+
+**For `DEPLOY_TARGET=brev:<name>` (restart stopped instance):**
+1. Run `brev start <name>` — one Bash call.
+2. Poll `brev ls` every 30s until STATUS = RUNNING and SHELL = READY. Then proceed to PHASE 4.
+
+**For `DEPLOY_TARGET=ssh:<user@host>`:**
+1. Verify: `ssh -i ~/.ssh/id_ed25519 <user@host> "echo ok"`
+2. Proceed directly to PHASE 4 on success.
+
+**Observer checklist** — emit at the start of PHASE 2 and reprint (with updates) on each
+phase transition and every 30s poll:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  Cosmos BYO-Video · setting up...  (elapsed: Xm Ys)          ║
+║  <GPU label> · $<rate>/hr · <MODEL_ID> (<MODEL_SIZE>, <be>)  ║
+╠══════════════════════════════════════════════════════════════╣
+║  [→] Provisioning instance                                   ║
+║  [ ] Shell ready                                             ║
+║  [ ] Scripts deployed                                        ║
+║  [ ] Installing dependencies          ETA ~8 min             ║
+║  [ ] Downloading model weights        ETA ~5 min             ║
+║  [ ] Starting Gradio                  ETA ~1 min             ║
+╠══════════════════════════════════════════════════════════════╣
+║  Cost so far: $0.00  |  Est. total setup: ~$<low>–$<high>    ║
+║  Brev dashboard: https://brev.dev                            ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+Mark each row `[✓]` when complete, `[→]` when active. Update elapsed and cost each reprint.
+Raw bash output is never surfaced in the checklist.
+
+Write progress to local machine `/tmp/byo_video_progress.json`:
+```json
+{"phase": 2, "status": "provisioning", "elapsed_s": 0, "instance": "<name>", "checklist": {"provision": "active", "shell": "pending", "scripts": "pending", "deps": "pending", "weights": "pending", "gradio": "pending"}}
+```
+
+Cost estimates by GPU tier:
+- H100 SXM ($3.54/hr): 10 min setup ~$0.59 · 20 min ~$1.18
+- H200 SXM ($4.20/hr): 20 min setup ~$1.40 · 30 min ~$2.10
+
+---
+
+### OBSERVER PROTOCOL — PHASE 3: WAIT FOR SHELL READY
+
+Applies when `brev create` did not already block until shell ready (e.g., restart path).
+Poll `brev ls` every 30s. Update the checklist `[→] Shell ready` row each poll.
+
+**On UNHEALTHY:**
+1. Update checklist: `[!] UNHEALTHY — recovering (3 min window)`.
+2. Poll every 30s for 3 minutes.
+3. If recovered: run `brev exec <name> "nvidia-smi"` — if GPU responds, continue.
+4. If still UNHEALTHY after 3 minutes:
+   - Try `brev reset <name>`. If succeeds → re-enter poll loop.
+   - If reset fails: `brev delete <name>`, rotate to next provider (PROVIDER FALLBACK table).
+     Emit one line: `✗ <type> UNHEALTHY — deleted, trying <next-type>`. Re-enter PHASE 2.
+   - If all providers exhausted: write failure result and exit.
+     `{"status":"failed","phase":3,"error":"All providers exhausted — UNHEALTHY","instance":"<last-name>"}`
+
+On each poll, write progress to local machine `/tmp/byo_video_progress.json`:
+```json
+{"phase": 3, "status": "waiting_shell", "elapsed_s": <N>, "instance": "<name>", "checklist": {"provision": "done", "shell": "active", "scripts": "pending", "deps": "pending", "weights": "pending", "gradio": "pending"}}
+```
+
+On SHELL READY: update checklist `[✓] Shell ready`, proceed to PHASE 4.
+
+---
+
+### OBSERVER PROTOCOL — PHASE 4: DEPLOY SCRIPTS
+
+Read and base64-encode each script. One Bash call per file. One Bash call per deploy.
+
+**Step 0 — Auto-deploy HF token (before scripts, always):**
+Check if a cached HF token exists locally. If so, deploy it to the instance so the setup script can authenticate without user interaction.
+```bash
+# Check local token
+cat ~/.cache/huggingface/token 2>/dev/null || echo "NO_TOKEN"
+```
+If a token is found (starts with `hf_`):
+```bash
+brev exec <name> "mkdir -p ~/.cache/huggingface"
+brev exec <name> "echo <token> > ~/.cache/huggingface/token"
+```
+This prevents the Step 2 HF auth failure that requires a full setup restart.
+
+```bash
+# Step 1: read + encode byo_video_setup.py (Bash call 1)
+python3 -c "import base64, sys; sys.stdout.write(base64.b64encode(open('<HOME>/.claude/scripts/byo_video_setup.py','rb').read()).decode())"
+# → capture B64_SETUP
+
+# Step 2: deploy byo_video_setup.py to instance (Bash call 2)
+brev exec <name> "python3 -c \"import base64; open('/tmp/byo_video_setup.py','wb').write(base64.b64decode('<B64_SETUP>'))\""
+```
+(Replace `<HOME>` with the absolute path to your home directory — `python3` does not expand `~` inside a string literal.)
+
+**Step 3** — Check file size before choosing deploy method for gradio_cr2_byo.py:
+```bash
+wc -c ~/.claude/scripts/gradio_cr2_byo.py
+```
+
+**Step 4a** — If size ≤ 100352 bytes (98KB): base64 encode and deploy:
+```bash
+python3 -c "import base64, sys; sys.stdout.write(base64.b64encode(open('<HOME>/.claude/scripts/gradio_cr2_byo.py','rb').read()).decode())"
+```
+→ capture B64_GRADIO, then:
+```bash
+brev exec <name> "python3 -c \"import base64; open('/tmp/gradio_cr2_byo.py','wb').write(base64.b64decode('<B64_GRADIO>'))\""
+```
+
+**Step 4b** — If size > 100352 bytes (>98KB): use brev copy (avoids brev exec argument buffer overflow):
+```bash
+brev copy ~/.claude/scripts/gradio_cr2_byo.py <name>:/tmp/gradio_cr2_byo.py
+```
+
+Update checklist: `[✓] Scripts deployed`
+
+Write progress to local machine `/tmp/byo_video_progress.json`:
+```json
+{"phase": 4, "status": "scripts_deployed", "elapsed_s": <N>, "instance": "<name>", "checklist": {"provision": "done", "shell": "done", "scripts": "done", "deps": "pending", "weights": "pending", "gradio": "pending"}}
+```
+
+---
+
+### OBSERVER PROTOCOL — PHASE 4-NIM: NIM-LOCAL ADDENDUM
+
+**Only when `INFERENCE_BACKEND=nim_local`. Otherwise skip to Phase 5.**
+
+The NIM (local Docker) backend pulls a NIM container from `nvcr.io/nim/nvidia/<model-short>:latest` and runs it on the target's port 8000. The Gradio app talks to the container via the standard OpenAI-compatible client (same code path as vLLM, just a different `VLLM_BASE_URL`). Works on any reachable target — Brev, SSH host, or local Docker — provided NGC_API_KEY and Docker are present. The user supplies the target via the Phase 1 picker; the skill never assumes a default host.
+
+**Source of truth for available VLM NIMs — fetch this URL every time the user selects NIM:**
+
+> [https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html](https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html)
+
+The `~/.claude/scripts/nim_catalog.py` helper does this automatically (and is also deployed to `/tmp/nim_catalog.py` on the target). The agent must:
+
+1. **In the Phase 1 picker (main session)** — when the user selects "NIM (local Docker)" as the backend, run `python3 ~/.claude/scripts/nim_catalog.py upstream` to refresh the canonical model list from the URL above. If a model name appears upstream that is NOT in `KNOWN_VLM_NIMS` (the slug map inside `nim_catalog.py`), surface a one-line note to the user (e.g., *"Heads-up: docs added `Foo VLM`; the byo-video skill doesn't know its nvcr.io short-id yet — file a one-line PR adding it to KNOWN_VLM_NIMS, or use Custom Checkpoint ID."*).
+2. **In observer Phase 4 (script deploy)** — deploy `nim_catalog.py` alongside the other scripts (see deploy block below).
+3. **In runtime debug (the morning runtime-agent loop)** — re-run `nim_catalog.py upstream` each session start to detect upstream catalog changes (deprecations, new models, version bumps).
+
+**Runtime NIM swap — out-of-band (not via a Gradio button):**
+
+A previous version wired a "Switch to selected NIM" button inside Gradio that streamed `nim_launch.sh` output to the browser. It was removed because a 5-15 min docker pull + 1-3 min vLLM warmup blows past Gradio's streaming heartbeat, so the UI froze even when the backend was making progress. The dropdown still lists every VLM NIM in the upstream catalog (so the user knows their options), but the swap itself is performed out-of-band by one of:
+
+1. **Runtime agent path (preferred)** — when the user says *"switch the NIM to X"*, Claude runs the SSH commands below, watches `docker logs -f cosmos-nim`, confirms `/v1/models` is back up, and tells the user to refresh the Gradio page. Gradio re-queries `/v1/models` on every page load and picks up the new served model id automatically.
+
+2. **Manual SSH path (no Claude needed)** — the Gradio info panel in `nim_local` mode displays this snippet directly:
+   ```bash
+   ssh <user@host>
+   docker rm -f cosmos-nim
+   MODEL=<short-id> CONTAINER_NAME=cosmos-nim PORT=8000 \
+     bash /tmp/nim_launch.sh <NGC_API_KEY>
+   # Then reload the Gradio page.
+   ```
+   Valid short-ids come from `python3 /tmp/nim_catalog.py list --no-probe` (or the static panel inside Gradio).
+
+**Agent runbook for "switch the NIM" requests:**
+1. Run `python3 ~/.claude/scripts/nim_catalog.py upstream` to refresh the catalog from `docs.nvidia.com/nim/vision-language-models/latest/introduction.html`. Surface any upstream model name not in `KNOWN_VLM_NIMS` as a one-line note.
+2. Resolve the user's request (e.g. *"Cosmos Reason2 2B"*) to a short-id (e.g. `cosmos-reason2-2b`) via the slug map in `nim_catalog.py`.
+3. SSH to the target. Run `docker rm -f cosmos-nim` then `MODEL=<short-id> bash /tmp/nim_launch.sh <NGC_API_KEY>`. Stream the log so the user can see progress.
+4. Verify with `curl -sf http://localhost:8000/v1/models | jq '.data[0].id'` — confirm the served model id matches.
+5. Tell the user to refresh the Gradio page.
+
+**Required env on the target:**
+- `NGC_API_KEY` (must start with `nvapi-`) — used by both `docker login nvcr.io` and the running container
+- `HF_TOKEN` — **not needed**; NIM ships the model
+
+**Deploy `nim_launch.sh` AND `nim_catalog.py` alongside the other scripts (Phase 4 step 1):**
+```bash
+# nim_launch.sh
+brev exec <name> "python3 -c \"import base64; open('/tmp/nim_launch.sh','wb').write(base64.b64decode('<B64_NIM_SH>'))\""
+brev exec <name> "chmod +x /tmp/nim_launch.sh"
+# nim_catalog.py — used by Gradio at startup AND by the runtime agent
+brev exec <name> "python3 -c \"import base64; open('/tmp/nim_catalog.py','wb').write(base64.b64decode('<B64_NIM_CATALOG>'))\""
+```
+(For SSH targets: replace `brev exec <name>` with `ssh -i ~/.ssh/id_ed25519 <user@host>`.)
+
+**`byo_video_setup.py` handles the NIM launch automatically** when `INFERENCE_BACKEND=nim_local`:
+- Step 2/2b — HF auth is **skipped**
+- Step 3 — NGC_API_KEY is **mandatory** (script exits if missing)
+- Step 9 (HF weights download) — **skipped**
+- Step 9-NIM (new) — runs `bash /tmp/nim_launch.sh` which:
+  1. Reuses an existing healthy container with the same name (idempotent)
+  2. Otherwise: `docker login nvcr.io`, `docker pull` the image, `docker run -d` per official build.nvidia.com snippet (`--gpus all --ipc host --shm-size=32GB -e NGC_API_KEY -v $LOCAL_NIM_CACHE:/opt/nim/.cache -u $(id -u) -p 8000:8000`)
+  3. Waits up to 1800s for `GET /v1/models` to respond (model download from NGC + load can take 10-15 min on first run for 8B)
+- Step 10 — Gradio launches with `VLLM_BASE_URL=http://localhost:8000/v1`. The Gradio app auto-detects the served model name via `/v1/models` (so `_SERVER_MODEL_ID` matches the NIM-served id, e.g. `nvidia/cosmos-reason2-8b`).
+
+**NIM image short-id resolution (in `byo_video_setup.py`):**
+```
+MODEL_ID=nvidia/Cosmos-Reason2-8B   →  short=cosmos-reason2-8b   →  nvcr.io/nim/nvidia/cosmos-reason2-8b:latest
+MODEL_ID=nvidia/Cosmos-Reason2-2B   →  short=cosmos-reason2-2b   →  nvcr.io/nim/nvidia/cosmos-reason2-2b:latest
+MODEL_ID=nvidia/Cosmos-Reason2-32B  →  short=cosmos-reason2-32b  →  nvcr.io/nim/nvidia/cosmos-reason2-32b:latest
+```
+Override at any time with `NIM_MODEL_SHORT` or full `NIM_IMAGE` env var.
+
+**NIM-specific runtime constraint:** the container caps at 5 images per prompt. The Gradio app clamps `max_frames` to 5 when `INFERENCE_BACKEND=nim_local` (vs 8 for vLLM). For single-image inference this is a no-op.
+
+**NIM-8B-FP8-THINK-EOS bug (greedy decode):** the FP8-quantized cosmos-reason2-8b NIM emits a bare `<think>` opener then an EOS-like token at `temperature=0`, finishing in 2-3 tokens with no reasoning trace and no final answer. Visible symptom in Gradio: response shows only `<think>` (or appears empty) and the run completes in <1s with `tok=2` or `tok=3` in `gradio_demo.log`. Workaround: keep temperature ≥ 0.3. The Gradio app defaults the slider to 0.6 in `nim_local` mode and clamps server-side calls to ≥0.3 as a safety net. Runtime monitor rule `nim_local_think_eos_truncation` flags any `[vllm done] X.Xs · 1|2|3 tok` line.
+
+**Failure modes the runtime monitor catches** (`byo_video_runtime_monitor.py` rule names):
+- `nim_local_container_down` — Gradio reports `[NIM] Container not responding at` (port 8000 unreachable)
+- `nim_local_image_unauthorized` — NGC denied the pull (key invalid or model not allowlisted)
+- `vllm_disconnect` — generic port-8000 failure (covers both vLLM and NIM-local container)
+
+---
+
+### OBSERVER PROTOCOL — PHASE 5: SETUP LAUNCH + LOG TAIL
+
+**This phase runs inside the observer subagent, not the main session.**
+
+Record `SETUP_DISPATCHED_AT` = now.
+
+**Pre-launch VRAM check (mandatory — runs before setup):**
+```bash
+brev exec <name> "nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits | head -1"
+```
+(For SSH: replace `brev exec <name>` with `ssh -i ~/.ssh/id_ed25519 <user@host>`.)
+
+Look up `MODEL_GPU_REQUIREMENTS[MODEL_SIZE].min_vram` in MB (multiply GB values by 1000):
+`2B`→40000 · `8B`→80000 · `32B`→141000 · `C3-8B`→40000 · `C3-32B`→141000 · `NEM-12B`→40000 · `QW3-2B`→8000 · `QW3-8B`→20000 · `QW3-32B`→64000 · `C3-super`→141000
+
+If `free_vram_mb < min_vram_mb`:
+  Write to `/tmp/byo_video_observer_result.json` on the LOCAL machine and exit immediately:
+  ```json
+  {"status":"failed","phase":5,"error":"insufficient_vram","vram_free_mb":<free>,"vram_needed_mb":<needed>,"model_size":"<MODEL_SIZE>","instance":"<name>"}
+  ```
+  Do NOT launch setup. The main session handles model switching via AskUserQuestion (see HALT-AND-ASK).
+
+If `free_vram_mb >= min_vram_mb`: proceed with the user's requested model — do not substitute.
+
+Launch setup (one Bash call — nohup so brev exec returns immediately). Pass `MODEL_NAME` and `MODEL_SIZE` explicitly so the setup script does not auto-select a different model:
+```bash
+brev exec <name> "nohup bash -c 'export INFERENCE_BACKEND=<backend> MODEL_ID=<model_id> MODEL_NAME=<model_id> MODEL_SIZE=<model_size> BREV_RATE_PER_HOUR=<rate> PATH=~/.local/bin:~/.cargo/bin:$PATH && python3 /tmp/byo_video_setup.py > /tmp/byo_video_setup.log 2>&1' &"
+```
+
+**Log tail loop (every 30s):** Tail the log, print a compact status line (not a full panel —
+the observer is headless). Look for step markers and errors. On each poll, write progress to local machine `/tmp/byo_video_progress.json`:
+```json
+{"phase": 5, "status": "<active_step>", "elapsed_s": <N>, "instance": "<name>", "checklist": {"provision": "done", "shell": "done", "scripts": "done", "deps": "active|done", "weights": "active|done|pending", "gradio": "pending"}}
+```
+(Update `deps` to `"done"` after Step 6 completes, `weights` to `"done"` after Step 9 completes.)
+
+```bash
+brev exec <name> "tail -60 /tmp/byo_video_setup.log 2>/dev/null || echo '(log not yet written)'"
+```
+
+Step markers to detect (scan log for these strings):
+
+```
+Step 1: GPU detect       Step 2: HF auth         Step 3: NGC API key
+Step 4: uv               Step 5: cosmos-reason2  Step 6: uv sync
+Step 7: PyAV/Gradio      Step 9: weights          Step 10: Gradio launch
+```
+
+**Error detection:** Scan for `Traceback`, `Error:`, `exit status 1`, `FAILED`.
+
+On error:
+1. Retry once: re-run the setup launch command, re-enter log tail loop.
+2. If error recurs: write failure result and exit:
+   ```json
+   {"status":"failed","phase":5,"error":"<one-line error>","instance":"<name>"}
+   ```
+   Write to `/tmp/byo_video_observer_result.json` on the local machine, then exit.
+   The main session handles user recovery via `AskUserQuestion`.
+
+---
+
+### OBSERVER PROTOCOL — PHASE 6: GRADIO LIVE + URL CAPTURE
+
+Update checklist: `[→] Starting Gradio`. Poll every 30s for the live flag. On each poll, write progress to local machine `/tmp/byo_video_progress.json`:
+```json
+{"phase": 6, "status": "waiting_gradio", "elapsed_s": <N>, "instance": "<name>", "checklist": {"provision": "done", "shell": "done", "scripts": "done", "deps": "done", "weights": "done", "gradio": "active"}}
+```
+
+```bash
+brev exec <name> "cat /tmp/gradio_live.flag 2>/dev/null"
+```
+
+When flag is present, read the URL:
+```bash
+brev exec <name> "cat /tmp/gradio_url.txt 2>/dev/null"
+```
+
+**Compute total cost:** `(time.time() - PROVISION_START_TS) / 3600 * rate_per_hour`
+
+Write success result to `/tmp/byo_video_observer_result.json` on the **local machine**:
+```json
+{"status":"live","url":"<gradio_url>","elapsed_s":<N>,"cost":<computed>,"instance":"<name>","rate":<rate>,"gpu":"<gpu_label>","model_id":"<model_id>","model_size":"<model_size>","backend":"<backend>"}
+```
+Then exit. The main session reads this file on task completion and displays the final panel.
+
+**LIVE final panel** (displayed by main session on success):
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  Cosmos BYO-Video  ·  LIVE  ✓                                ║
+║  <GPU label> · $<rate>/hr · elapsed: <N>m <S>s               ║
+╠══════════════════════════════════════════════════════════════╣
+║  [✓] Pre-checks                                              ║
+║  [✓] Model & environment selected                            ║
+║  [✓] Instance: <name> (<GPU type>)                           ║
+║  [✓] SHELL READY                                             ║
+║  [✓] Scripts deployed                                        ║
+║  [✓] Setup complete                                          ║
+║  [✓] Gradio live                                             ║
+╠══════════════════════════════════════════════════════════════╣
+║  URL:  <gradio_url>                                          ║
+║  Total setup cost: ~$<computed>  |  Link valid 72h           ║
+║  Kill the Brev instance when you're done to stop billing.    ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+Do NOT auto-terminate the instance.
+
+---
+
+### POST-LIVE — Runtime Monitor (optional, opt-in)
+
+Once Gradio is live, the user is on their own — but the Gradio UI swallows most server-side
+errors as a generic "Error" toast. Errors at preprocess, prefill, or generate stages are
+fully visible in `/tmp/gradio_demo.log` on the remote, but invisible in the browser.
+
+The **runtime monitor** is a lightweight polling daemon (`~/.claude/scripts/byo_video_runtime_monitor.py`)
+that watches the remote Gradio process, GPU stats, and log tail; pattern-matches errors
+against a rule catalog (cuda_oom, pyav_decode, preprocess_empty, shape_mismatch,
+vllm_disconnect, process_killed, broken_pipe, torch_compile_fail, generic_traceback,
+process_disappeared); and saves per-inference metrics for later review.
+
+After the LIVE panel, fire `AskUserQuestion` to offer the monitor:
+
+```
+AskUserQuestion: "Gradio is live. Spawn the runtime monitor to watch for errors and capture session metrics?"
+Options:
+  "Yes (Recommended)"  — "Polls every 30s; surfaces errors with suggested fixes; saves all inference metrics for later questions"
+  "Skip"               — "No background watcher. Spawn later with: python3 ~/.claude/scripts/byo_video_runtime_monitor.py poll --remote <host>"
+```
+
+If yes, launch the daemon:
+
+```bash
+nohup python3 ~/.claude/scripts/byo_video_runtime_monitor.py poll \
+  --remote <user@host> --rate <rate_per_hour> \
+  --session-id <session_name> --model-id <model_id> \
+  > /tmp/byo_video_runtime_monitor.out 2>&1 &
+```
+
+Then schedule a 1-min cron progress loop that reads the alert stream:
+
+```
+CronCreate({
+  cron: "*/1 * * * *",
+  prompt: "Read /tmp/byo_video_runtime_state.json and /tmp/byo_video_runtime_alerts.jsonl. Compare alert line count to /tmp/byo_video_runtime_alerts_seen.txt (default 0). For each new alert: print one-line summary 'severity rule: summary — fix'. Update the seen counter. Then print one-line state: 'gradio=alive|dead | GPU util=N% mem=Xused/Yfree | alerts=N metrics=N'. If gradio_alive=false, fire AskUserQuestion (load via ToolSearch) with options 'Restart Gradio' / 'Investigate log' / 'Abort'. Cancel this cron when user dismisses the monitor.",
+  recurring: true
+})
+```
+
+**Output files (all local /tmp):**
+- `byo_video_runtime_state.json` — current snapshot (overwritten each poll)
+- `byo_video_runtime_alerts.jsonl` — append-only alert stream
+- `byo_video_session_metrics.jsonl` — append-only inference history (prompt, response, ttft_s, gen_s, tokens, model_id)
+
+**Querying session data later:**
+```bash
+python3 ~/.claude/scripts/byo_video_runtime_monitor.py status
+python3 ~/.claude/scripts/byo_video_runtime_monitor.py alerts -v
+python3 ~/.claude/scripts/byo_video_runtime_monitor.py metrics
+```
+
+**Stopping the monitor:**
+```bash
+python3 ~/.claude/scripts/byo_video_runtime_monitor.py stop
+```
+Also cancel the cron loop (`CronDelete <id>`) when stopping.
+
+The monitor is read-only on the remote. Polling cost: one SSH bundle every 30s, ~1KB.
+
+---
+
+### SSH DEPLOYMENTS (non-Brev)
+
+PHASE 0–4 run in the main session with SSH commands replacing `brev exec`. After scripts are
+deployed, the same HANDOFF applies — spawn the observer with `DEPLOY_TARGET=ssh:<user@host>`.
+The observer runs PHASE 5–6 via SSH instead of `brev exec`.
+
+Deploy scripts:
+```bash
+ssh -i ~/.ssh/id_ed25519 <user@host> "python3 -c \"import base64; open('/tmp/byo_video_setup.py','wb').write(base64.b64decode('<B64>'))\""
+ssh -i ~/.ssh/id_ed25519 <user@host> "python3 -c \"import base64; open('/tmp/gradio_cr2_byo.py','wb').write(base64.b64decode('<B64>'))\""
+```
+
+Launch setup:
+```bash
+ssh -i ~/.ssh/id_ed25519 <user@host> "nohup bash -c 'export INFERENCE_BACKEND=<backend> MODEL_ID=<model_id> MODEL_NAME=<model_id> MODEL_SIZE=<model_size> && python3 /tmp/byo_video_setup.py > /tmp/byo_video_setup.log 2>&1' &"
+```
+
+Tail logs:
+```bash
+ssh -i ~/.ssh/id_ed25519 <user@host> "tail -60 /tmp/byo_video_setup.log 2>/dev/null"
+```
+
+URL capture:
+```bash
+ssh -i ~/.ssh/id_ed25519 <user@host> "cat /tmp/gradio_live.flag 2>/dev/null"
+ssh -i ~/.ssh/id_ed25519 <user@host> "cat /tmp/gradio_url.txt 2>/dev/null"
+```
+
+---
+
+---
+
+## HALT-AND-ASK PROTOCOL
+
+During PHASE 0–1 (main session): all user decisions are captured in the picker. If an edge case
+requires a follow-up question, fire `AskUserQuestion` before spawning the observer.
+
+During PHASE 2–6 (observer): the observer never calls `AskUserQuestion`. On unrecoverable
+failure it writes `/tmp/byo_video_observer_result.json` and exits. The main session reads the
+result on task completion notification and fires `AskUserQuestion` for recovery.
+
+**Load AskUserQuestion** before firing: `ToolSearch({ query: "select:AskUserQuestion" })`.
+
+### Exception triggers and question templates
+
+**Observer failure (any phase) — triggered by main session progress loop detecting failure JSON:**
+
+Read `/tmp/byo_video_progress.json` for last-known state before firing AskUserQuestion.
+
+```
+AskUserQuestion: "Observer failed at Phase <N>: <error>.
+Last checklist state: [✓] provision [✓] shell [→] scripts [ ] deps [ ] weights [ ] gradio
+What next?"
+Options:
+  "Retry — spawn a new observer on the same instance"
+  "Provision a new instance (current will be deleted)"
+  "Abort — delete instance and exit"
+```
+
+(Replace the checklist state line with actual values read from `/tmp/byo_video_progress.json` — use `[✓]` for `"done"`, `[→]` for `"active"`, `[ ]` for `"pending"`.)
+
+On "Retry": spawn a new observer with the same state, `DEPLOY_TARGET=brev:<existing-name>`.
+On "New instance": delete the failed instance, spawn a new observer with `DEPLOY_TARGET=brev:new`.
+On "Abort": `brev delete <name>`, exit skill.
+
+**Insufficient VRAM — triggered by main session detecting `"insufficient_vram"` in failure JSON:**
+
+Read `vram_free_mb` and `vram_needed_mb` from the failure JSON. Build options from MODEL_GPU_REQUIREMENTS — include only models whose `min_vram_mb` ≤ `vram_free_mb`.
+
+```
+AskUserQuestion: "The requested model (<MODEL_SIZE>, needs ~<vram_needed_mb/1000>GB VRAM) won't fit on <instance>
+(<vram_free_mb/1000>GB free). Switch to a model that fits, or abort?"
+Options (show only what fits — examples for 40GB free):
+  "Cosmos Reason2 2B (needs ~40GB)"    → MODEL_ID=nvidia/Cosmos-Reason2-2B, MODEL_SIZE=2B
+  "Cosmos3-Nano-Reasoner (needs ~40GB)" → MODEL_ID=nvidia/Cosmos3-Nano-Reasoner, MODEL_SIZE=C3-8B
+  "Abort — exit without deleting instance"
+```
+
+On model switch: update MODEL_ID, MODEL_SIZE, MODEL_NAME to the new selection, respawn observer.
+On Abort: exit skill. Do not delete the instance (user may want it for other work).
+
+**Rule:** Never silently substitute a different model. If the requested model does not fit and there
+is no confirmed user-approved alternative, always ask. A silent downgrade is a broken demo.
+
+**Rule:** For any exception not listed here, apply the closest matching template. The goal is
+one clear question with 2–3 concrete options. Never ask open-ended questions mid-deployment.
+
+---
+
+### MODEL_GPU_REQUIREMENTS — Read before provisioning any instance
+
+| MODEL_SIZE | Min VRAM | Brev type | Rate | Avoid |
+|---|---|---|---|---|
+| `2B` | 40 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | — |
+| `8B` | 80 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | A40 (48GB too tight) |
+| `32B` | 141 GB | `gpu-h200-sxm.1gpu-16vcpu-200gb` | $4.20/hr | H100 single-GPU |
+| `C3-8B` | 40 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | — |
+| `C3-32B` | 141 GB | `gpu-h200-sxm.1gpu-16vcpu-200gb` | $4.20/hr | H100 single-GPU |
+| `NEM-12B` | 40 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | — |
+| `QW3-2B` | 8 GB | Any GPU ≥8GB | varies | — |
+| `QW3-8B` | 20 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | — |
+| `QW3-32B` | 64 GB | `gpu-h100-sxm.1gpu-16vcpu-200gb` | $3.54/hr | — |
+| `C3-super` | TBD (32B) | `gpu-h200-sxm.1gpu-16vcpu-200gb` | $4.20/hr | — |
+
+> **C3-super** is a native MODEL_SIZE key in both `byo_video_setup.py` and `gradio_cr2_byo.py`. Requires H200 SXM (141GB VRAM). VLLM_TIMEOUT is 420s for this size (32B torch.compile takes ~5 min).
+
+**32B and C3-32B — H200 only.** H100 80GB is insufficient. If the user has an existing H100 and selects 32B: warn them and offer to provision an H200.
+
+**H200 fallback order for 32B/C3-32B:**
+
+| Priority | Type | Rate |
+|---|---|---|
+| 0 | Existing stopped H200 (from brev ls) | existing rate |
+| 1 | `gpu-h200-sxm.1gpu-16vcpu-200gb` | $4.20/hr |
+| 2 | `digitalocean_H200_sxm5` | $4.13/hr |
+
+### PROVIDER FALLBACK — Auto-rotation on provisioning failure
+
+Rotate silently (no AskUserQuestion) on UNHEALTHY after 3 min, `brev create` error, or reset failure. Emit one line per rotation: `✗ <type> failed — trying <next-type>`.
+
+**Standard (all models except 32B/C3-32B):**
+
+| Priority | Type | GPU | Rate |
+|---|---|---|---|
+| 1 | `gpu-h100-sxm.1gpu-16vcpu-200gb` | H100 SXM 80GB | $3.54/hr |
+| 2 | `hyperstack_A100_80G` | A100 80GB | $1.62/hr |
+| 3 | `hyperstack_H100` | H100 80GB | $2.28/hr |
+| 4 | `scaleway_A40` | A40 48GB | $1.10/hr (2B LOW_VRAM only) |
+
+If rotating to a tier >$1.50/hr more expensive than the current one: display a one-line cost warning, wait 30s (allows interruption), then proceed.
+
+Only AskUserQuestion when all providers exhausted — present the failure summary and options.
+
+---
+
+---
+
+## Supported models
+
+| Model | Size | Min VRAM | MODEL_SIZE | Use case |
+|---|---|---|---|---|
+| Cosmos Reason2 BF16 | 2B VLM | 40 GB | `2B` | Video understanding: robotics, AV, Metropolis |
+| Cosmos Reason2 FP8 | 2B VLM | 24 GB | `2B` | Same, quantized |
+| Cosmos Reason2 BF16 | 8B VLM | 80 GB | `8B` | Higher quality video understanding |
+| Cosmos Reason2 BF16 | 32B VLM | 141 GB | `32B` | Public; H200 SXM minimum (H100 80GB insufficient) |
+| Cosmos3-Nano-Reasoner | 8B VLM | 40 GB | `C3-8B` | Public; was Cosmos3-Reasoner-8B-Private |
+| Cosmos3-Reasoner 2B/32B | 2B/32B | 40/80+ GB | `C3-2B`, `C3-32B` | Gated HF_TOKEN; nvidia org required |
+| Nemotron-Nano-12B-v2-VL BF16 | 12B VLM | 40 GB | `NEM-12B` | vLLM-only; gated; opencv backend |
+| Nemotron-Nano-12B-v2-VL FP8 | 12B VLM | 24 GB | `NEM-12B` | FP8 quantized |
+| Qwen3-VL-2B Instruct/FP8/Thinking | 2B VLM | 8 GB | `QW3-2B` | Public (no HF_TOKEN); vLLM-only |
+| Qwen3-VL-8B Instruct/FP8/Thinking | 8B VLM | 20 GB | `QW3-8B` | Public; higher quality |
+| Qwen3-VL-32B Instruct/FP8/Thinking | 32B VLM | 64+ GB | `QW3-32B` | Public; best quality |
+| Cosmos Transfer2.5 | Gen | 80 GB+ | — | Video-to-video generation, sim2real |
+| Cosmos Predict2 | Gen | 80 GB+ | — | World model generation |
+
+Transfer2.5 and Predict2 are datacenter-only (H100/A100 80GB+).
+
+### Nemotron-Nano-12B-v2-VL notes
+
+- **Gated model** — HF_TOKEN required with nvidia org access
+- **vLLM 0.14.0+** — vLLM 0.11.0 is ABI-incompatible with torch 2.9.0+cu128. `byo_video_setup.py` auto-pins to 0.14.0 on CUDA 12.8 (driver < 575). Do not pin lower.
+- **opencv backend** — `VLLM_VIDEO_LOADER_BACKEND=opencv` is injected automatically. PyAV is not supported.
+- **file:// video protocol** — Gradio copies video to `/tmp/gradio_upload.mp4` and sends `file:///tmp/gradio_upload.mp4` to vLLM. `--allowed-local-media-path /tmp` is required (set automatically by setup script NEM-12B config).
+- **FLASHINFER bypass** — `FLASHINFER_DISABLE_VERSION_CHECK=1` is injected automatically (flashinfer package/cubin version mismatch in cosmos-reason2 venv).
+- **NVFP4-QAD variant** — requires a special vLLM build; not available in standard setup. Use BF16 or FP8.
+- **Launch**: `MODEL_SIZE=NEM-12B INFERENCE_BACKEND=vllm python3 /tmp/byo_video_setup.py`
+
+### Qwen3-VL notes
+
+- **Public model** — no HF_TOKEN required
+- **vLLM only** — uses same `file://` video URL protocol as Nemotron; HF inference backend not supported
+- **`--allowed-local-media-path /tmp`** required — set automatically in QW3-* configs
+- **Variant picker** — Gradio checkpoint dropdown shows Instruct, FP8, and Thinking for each size
+- **Thinking variant** — extended reasoning mode; max_tokens should be ≥2048 for best results
+- **VRAM**: 2B~8GB, 8B~20GB, 32B~64GB (FP8 halves these)
+- **Launch**: `MODEL_SIZE=QW3-8B INFERENCE_BACKEND=vllm python3 /tmp/byo_video_setup.py`
+
+---
+
+## VLM NIM Catalog (for `INFERENCE_BACKEND=nim_local`)
+
+Canonical catalog: `~/.claude/scripts/nim_catalog.py` → `KNOWN_VLM_NIMS`. The agent walks BOTH `https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html` AND every versioned release-notes page in `KNOWN_RELEASE_VERSIONS` to keep older containers (e.g. Cosmos Reason1 7B) discoverable when a newer release drops them from the introduction table. When a name appears upstream that is NOT in `KNOWN_VLM_NIMS`, surface it to the user as a one-line PR-this hint.
+
+Two catalogs to keep separate:
+
+| Catalog | URL | What it lists | Auth |
+|---|---|---|---|
+| **Self-host Docker images** (used by `nim_local`) | `nvcr.io/nim/<vendor>/<short-id>:latest` (entitlements at `docs.nvidia.com/nim/...`) | Containers you can `docker pull` and run on your own GPU | NGC_API_KEY (`nvapi-…`) |
+| **Hosted serverless API** (separate path) | `integrate.api.nvidia.com/v1/chat/completions` (catalog at `build.nvidia.com`) | Subset of NIMs NVIDIA serves for you | NGC_API_KEY |
+
+CR2-2B is in the Docker catalog only. CR2-8B is in both. The "[NIM] Skipped — not in public NVCF catalog" message in Gradio refers to the hosted-API catalog and does NOT mean the local container is unavailable.
+
+### Video-capable NIMs (relevant to `/byo-video`)
+
+| Family | Short-id | Min VRAM | Notes |
+|---|---|---|---|
+| Cosmos Reason2 | `cosmos-reason2-2b` | 20 GB | FP8; reasoning; temp ≥ 0.3 to avoid `<think>+EOS` bug at greedy decode. Container only — not on hosted API. |
+| Cosmos Reason2 | `cosmos-reason2-8b` | 40 GB | FP8; reasoning; Efficient Video Sampling (EVS); same temp constraint as 2B. Container + hosted API. |
+| Cosmos Reason2 | `cosmos-reason2-32b` | 80 GB | May require allowlisting via build.nvidia.com. |
+| Cosmos Reason1 | `cosmos-reason1-7b` | 24 GB | Older release; preserved via release-notes walk. |
+| Nemotron | `nemotron-3-nano-omni-30b-a3b-reasoning` | 40 GB | Specialized container; release 1.7.0+. |
+| Nemotron | `nemotron-nano-12b-v2-vl` | 40 GB | Image+video; vLLM-style backend. |
+| Mistral | `ministral-14b-instruct-2512` | 40 GB | Tool calling; 100k context on L40S. |
+| Qwen | `qwen3.5-35b-a3b` | 40 GB | MoE; high-concurrency video constraints. |
+| Qwen | `qwen3.5-122b-a10b` | 140 GB | MoE; KV cache saturation risk on long video. Multi-GPU. |
+| Qwen | `qwen3.5-397b-a17b` | 400 GB | Video not enabled by default — config flag required. Multi-node. |
+| Qwen | `qwen3.6-35b-a3b` | 40 GB | MoE; SGLang backend. |
+| Gemma | `gemma-4-31b-it` | 40 GB | Structured output not supported. |
+
+### Image-only NIMs (filtered OUT of `/byo-video` by `list_video_nims()`)
+
+`mistral-medium-3.5-128b` · `mistral-small-4-119b-2603` · `mistral-small-3.2-24b-instruct-2506` · `mistral-large-3-675b-instruct-2512` · `kimi-k2.5` · `kimi-k2.6` · `qwen3.6-27b` · `llama-3.1-nemotron-nano-vl-8b-v1` · `llama-3.2-11b-vision-instruct` · `llama-3.2-90b-vision-instruct` · `llama-4-maverick-17b-128e-instruct` · `llama-4-scout-17b-16e-instruct` · `nemotron-parse-v1.2` · `nemotron-3-content-safety`
+
+Adding a new NIM:
+
+1. Find its row in either the latest [introduction](https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html) or a [release notes](https://docs.nvidia.com/nim/vision-language-models/1.7.0/release-notes.html) page.
+2. Read the model card linked from that row — note image short-id, served model ID, VRAM minimum, and whether the card mentions multi-frame video input.
+3. Append a new `NimImage(...)` line to `KNOWN_VLM_NIMS` in `~/.claude/scripts/nim_catalog.py` with `supports_video=` set correctly. Append the new release version to `KNOWN_RELEASE_VERSIONS` if it's newer than the latest entry.
+4. Mirror the change to `<repo>/.claude/scripts/nim_catalog.py` and commit.
+
+Querying from the agent or runbook:
+
+```bash
+python3 ~/.claude/scripts/nim_catalog.py upstream      # raw upstream model-name list
+python3 ~/.claude/scripts/nim_catalog.py list --no-probe  # full known catalog as JSON
+python3 -c "from nim_catalog import list_video_nims; \
+            [print(n.short_id, n.min_vram_mb) for n in list_video_nims()]"
+```
+
+---
+
+## VRAM auto-selection
+
+The setup script (`byo_video_setup.py`) handles all of this automatically. Rules as of 2026-04-21:
+
+**Model selection** — always CR2-2B for the live demo (8B fails the <60s inference target on non-H100 GPUs). Force 8B via `MODEL_NAME=nvidia/Cosmos-Reason2-8B` env var if quality > speed.
+- ≥ 40000 MiB free → `nvidia/Cosmos-Reason2-2B`
+- < 40000 MiB → CR2-2B with LOW_VRAM mode (fps=1, reduced resolution)
+
+**FPS/pixel tier** — detected by GPU name (not free VRAM), because workstation GPUs like RTX PRO 6000 have large VRAM but slower prefill compute:
+| Tier | Condition | fps | max_pixels | Expected inference |
+|---|---|---|---|---|
+| H100/A100 | GPU name contains H100, A100, H200, GB200 | 2 | 1,048,576 | ~44s (validated H100) |
+| High-VRAM (non-H100) | ≥40GB free, non-H100 (RTX PRO, A40, A30, etc.) | 1 | 524,288 | ~54s (validated RTX PRO 6000 97GB) |
+| Low-VRAM | <40GB free | 1 | 131,072 | ~80-120s |
+| Ultra-Low-VRAM | <8GB free (RTX 5070, GTX 3090, etc.) | 1 | 65,536 | ~120-180s; may OOM on videos >5s at 720p — pre-resize to 360p |
+
+**Pre-kill**: setup script kills any process on port 7860 BEFORE measuring VRAM, so stale processes don't skew the tier selection.
+
+Transfer2.5 / Predict2: abort if < 80000. Do not proceed.
+
+---
+
+## Environment detection (LOCAL FIRST)
+
+Check in this order:
+
+1. **Local GPU**: `nvidia-smi` succeeds → local path, no cloud needed
+2. **Brev**: `brev ls` succeeds → Brev path
+3. **Nebius**: `NEBIUS_ENDPOINT` is set → Nebius path
+4. **None**: ask "Which environment?"
+
+---
+
+## Primary flow — Brev web demo (most common)
+
+### Step 1 — Create or reuse instance
+
+```bash
+# Create new instance — use model-aware GPU type (see MODEL_GPU_REQUIREMENTS)
+# For 32B: brev create <name> --gpu-name H200 --type gpu-h200-sxm.1gpu-16vcpu-200gb
+# For ≤8B: brev create <name> --gpu-name H100 --type gpu-h100-sxm.1gpu-16vcpu-200gb
+
+# Or list existing
+brev ls
+```
+
+Wait for STATUS: RUNNING. Then get the public IP:
+```bash
+brev exec <name> "curl -s ifconfig.me"
+```
+
+### Step 2 — Bootstrap
+
+Run once per fresh instance. All commands via `brev exec <name> "<cmd>"`.
+
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone cosmos-reason2 (provides model code + sample video)
+git clone https://github.com/nvidia-cosmos/cosmos-reason2.git ~/cosmos-reason2
+
+# Install dependencies
+cd ~/cosmos-reason2 && export PATH=~/.local/bin:~/.cargo/bin:$PATH && uv sync --extra cu128
+
+# Install PyAV (required on Hyperstack — FFmpeg not in PATH)
+uv pip install "av==16.1.0"
+
+# Download model weights (CR2-2B ~8GB, first-run only, ~5-10 min on cloud bandwidth)
+export HF_TOKEN=hf_...
+uv run huggingface-cli download nvidia/Cosmos-Reason2-2B \
+  --local-dir ~/cosmos-reason2/models/Cosmos-Reason2-2B
+```
+
+### Step 3 — Deploy scripts and launch
+
+Two scripts must be present on the instance:
+- `/tmp/byo_video_setup.py` — shows live progress + ETAs, launches Gradio, prints clickable URL
+- `/tmp/gradio_cr2_byo.py` — the Gradio app itself (called by setup script)
+
+Both live at `~/.claude/scripts/` on your local machine (canonical, versioned). Deploy via base64:
+
+```bash
+# Deploy both scripts to the instance
+for script in byo_video_setup gradio_cr2_byo; do
+  B64=$(base64 -i ~/.claude/scripts/${script}.py | tr -d '\n')
+  brev exec <name> "python3 -c \"import base64; open('/tmp/${script}.py','wb').write(base64.b64decode('${B64}'))\""
+done
+```
+
+Then run setup (streams live progress to this terminal).
+Note: pass env vars as separate exports in the remote quoted command — HF_TOKEN is auto-read by the script from `~/.cache/huggingface/token` on the instance (do not pass it manually):
+```bash
+brev exec <name> "export INFERENCE_BACKEND=vllm MODEL_ID=nvidia/Cosmos-Reason2-2B BREV_RATE_PER_HOUR=3.70 PATH=~/.local/bin:~/.cargo/bin:$PATH && python3 /tmp/byo_video_setup.py"
+```
+
+The script will:
+1. Print a 9-step setup dashboard and begin executing
+2. Detect GPU + VRAM tier (H100 / High-VRAM / Low-VRAM / Ultra-Low-VRAM)
+3. Validate HF token (whoami check — fails fast if expired)
+4. Install any missing deps (uv, repos, PyAV, Gradio)
+5. Download model weights with retry logic
+6. Launch Gradio and print a **clickable hyperlink** to the public `gradio.live` URL
+7. Report elapsed time and credits spent throughout
+
+### Step 4 — The URL appears at the end
+
+Example output:
+```
+──────────────────────────────────────────────────────────────
+  Cosmos Reason2 Demo — Ready
+──────────────────────────────────────────────────────────────
+  URL:  https://xxxxxxxxxxxx.gradio.live
+  Upload any MP4 → type a prompt → click Run Inference
+  Link valid for 72h. Kill instance when done.
+──────────────────────────────────────────────────────────────
+```
+
+The URL is an OSC 8 hyperlink — click it directly in iTerm2 or Terminal.app (macOS). Valid for 72 hours.
+
+### Step 5 — Kill instance when done
+
+Delete the instance from the Brev dashboard or run `brev delete <name>`. Do NOT auto-terminate.
+
+---
+
+## Local web demo (no cloud billing)
+
+Same Gradio app, runs on the user's own GPU machine.
+
+Prerequisites:
+```bash
+export HF_TOKEN=hf_...
+# Check VRAM — must be ≥40GB for CR2-2B
+nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits | head -1
+```
+
+Bootstrap (once):
+```bash
+git clone https://github.com/nvidia-cosmos/cosmos-reason2.git ~/cosmos-reason2
+cd ~/cosmos-reason2
+uv sync --extra cu128
+uv pip install "av==16.1.0" gradio
+uv run huggingface-cli download nvidia/Cosmos-Reason2-2B \
+  --local-dir ~/cosmos-reason2/models/Cosmos-Reason2-2B
+```
+
+Launch:
+```bash
+export MODEL_DIR=~/cosmos-reason2/models/Cosmos-Reason2-2B
+export MODEL_NAME=nvidia/Cosmos-Reason2-2B
+cd ~/cosmos-reason2
+uv run python /tmp/gradio_cr2_byo.py
+```
+
+Open `http://localhost:7860` in any browser. No kill alert needed — local machine.
+
+**Claude auth on local:** If running via Claude Code on a headless SSH machine, check auth first:
+```bash
+claude auth status
+```
+If `loggedIn: false`: `claude auth login --console` (API/console.anthropic.com users) or `claude auth login` (Claude.ai). On SSH — a URL prints; open it in your local browser.
+
+---
+
+## Headless inference (programmatic / no browser)
+
+For CI or batch use where no browser is needed. Results go to JSON only.
+
+```bash
+export HF_TOKEN=hf_...
+export BYO_VIDEO=/path/to/video.mp4
+export MODEL_DIR=~/cosmos-reason2/models/Cosmos-Reason2-2B
+export MODEL_NAME=nvidia/Cosmos-Reason2-2B
+export OUT_FILE=/tmp/byo_video_reason2_results.json
+export PROVIDER=brev  # or local
+cd ~/cosmos-reason2
+uv run python /tmp/smoke_cr2_byo.py
+```
+
+Results at `/tmp/byo_video_reason2_results.json`.
+
+---
+
+## Nebius (OpenAI-compatible API endpoint)
+
+Nebius runs Reason2 as a vLLM serving endpoint — no SSH, no Gradio needed. Useful for API integration testing, not for interactive browser demos.
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="https://<instance>.nebius.ai/v1", api_key="<nebius-key>")
+response = client.chat.completions.create(
+    model="nvidia/Cosmos-Reason2-2B",
+    messages=[{"role": "user", "content": [
+        {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,<b64>"}},
+        {"type": "text", "text": "Describe what is happening in this video."}
+    ]}]
+)
+```
+
+Write result to `/tmp/byo_video_reason2_results.json`. Delete the endpoint when done.
+
+---
+
+## Gradio app script
+
+Canonical source: **`~/.claude/scripts/gradio_cr2_byo.py`** (versioned 2026-04-21).
+
+Features (as of 2026-04-21):
+- **Checkpoint selector** — Advanced Settings accordion has a preset dropdown (CR2-2B base, CR2-2B FP8, CR2-8B NVFP4, NIM 2B) plus a custom model ID field. Any HF model ID or local path is accepted.
+- **On-demand load/unload** — switching checkpoints does `del model → gc.collect() → cuda.empty_cache()` before loading the next variant. VRAM is confirmed free before loading.
+- **Run All Variants button** — sequential benchmark: FP8 → NVFP4 → NIM, each unloaded before the next. Results saved to `/tmp/byo_video_benchmark.json`.
+- **Right-side status panel** — replaces the grey loading box. Shows Step N/5 WIP tracker (resolve / load / preprocess / prefill / generate) with ✅/⟳/— per step, plus live token metrics: prefill count, generated count (running), TTFT, inference time.
+- **NIM mode** — calls NVCF API (`https://integrate.api.nvidia.com/v1/chat/completions`) via NGC_API_KEY (nvapi- prefix). Extracts up to 8 JPEG frames from the video and sends them as image content. No local model load needed.
+- LOW_VRAM mode, PyAV backend, qwen_vl_utils pipeline, auto-cap, results JSON — all retained from 2026-04-20.
+
+Deploy to instances via base64 as shown in the deploy section.
+
+**Do not embed the source here.** The canonical file is the source of truth.
+
+### Checkpoint selector usage
+
+| Method | How |
+|---|---|
+| Preset (base, FP8, NVFP4, NIM) | Advanced Settings → Checkpoint dropdown |
+| Custom HF ID | Advanced Settings → Custom Checkpoint ID field (overrides dropdown) |
+| Custom local path | Same custom field — accepts `/path/to/model` |
+| Env var (headless) | `export CR2_CHECKPOINT=nvidia/Cosmos-Reason2-2B-FP8` before setup |
+
+For multi-variant benchmarking without the UI, click **Run All Variants** — runs FP8 → NVFP4 → NIM sequentially.
+
+### NIM mode requirements
+
+| Item | Value |
+|---|---|
+| NGC_API_KEY | `nvapi-...` prefix (set in env before setup, passed to Gradio) |
+| Model identifier | `nvidia/cosmos-reason2-2b` (NVCF catalog) |
+| Video input | Up to 8 JPEG frames extracted by PyAV at selected fps |
+| Auth header | `Authorization: Bearer $NGC_API_KEY` |
+| Output | Streamed via SSE, same JSON results format as HF path |
+
+Set `NGC_API_KEY` before running `byo_video_setup.py` — it passes it through to the Gradio process env.
+
+### Setup script — multi-variant mode
+
+Set `MULTI_VARIANT=true` to also pre-download FP8 and NVFP4 model weights during setup:
+
+```bash
+export HF_TOKEN=hf_...
+export NGC_API_KEY=nvapi-...
+export MULTI_VARIANT=true
+python3 /tmp/byo_video_setup.py
+```
+
+Without `MULTI_VARIANT=true`, only the base model downloads. FP8/NVFP4 will download from HF on first use in Gradio (with HF_TOKEN).
+
+### Env vars (single-model mode)
+
+| Var | Default | Notes |
+|---|---|---|
+| `MODEL_NAME` | `nvidia/Cosmos-Reason2-2B` | HF model ID to load at startup |
+| `MODEL_DIR` | `~/cosmos-reason2/models/Cosmos-Reason2-2B` | Local path |
+| `HF_TOKEN` | — | Required for gated model download |
+| `NGC_API_KEY` | — | Required for NIM mode (`nvapi-` prefix) |
+| `MULTI_VARIANT` | false | `true` = also download FP8 + NVFP4 during setup |
+| `GRADIO_PORT` | 7860 | Gradio server port |
+| `GRADIO_SHARE` | true | Set `false` to disable public link |
+| `GRADIO_FPS` | tier-based | Passed by setup script |
+| `GRADIO_MAX_PIXELS` | tier-based | Passed by setup script |
+| `GRADIO_PREFILL_TPS` | tier-based | Passed by setup script |
+| `LOW_VRAM` | auto | Set `true` to force low-VRAM mode |
+| `OUT_FILE` | `/tmp/byo_video_reason2_results.json` | Per-run results JSON path |
+
+---
+
+## Cosmos cookbook structure (as of 2026-04-17)
+
+The cookbook repo restructured. **`deploy/` directory no longer exists.** Old shell script paths are invalid.
+
+| What | New location |
+|---|---|
+| Brev Reason2 setup script | `docs/getting_started/brev/reason2/setup_script.sh` |
+| Worker safety recipe (Python) | `docs/recipes/inference/reason2/worker_safety/worker_safety.py` |
+| Transfer2.5 real augmentation | `docs/recipes/inference/transfer2_5/inference-real-augmentation/inference.md` |
+| Predict2 ITS | `docs/recipes/inference/predict2/inference-its/inference.md` |
+
+For BYO-video inference, **do not use cookbook scripts** — use `gradio_cr2_byo.py` (web demo) or `smoke_cr2_byo.py` (headless) directly against the `cosmos-reason2` repo environment.
+
+---
+
+## PyAV backend patch (always apply)
+
+Required on Hyperstack and similar cloud images — FFmpeg is not in system PATH so torchcodec fails. Already embedded in both `gradio_cr2_byo.py` and `smoke_cr2_byo.py`.
+
+If writing a new inference script, prepend this before loading the processor:
+
+```python
+from transformers import video_processing_utils
+from transformers.video_utils import load_video as _load_video
+
+def _patched_fetch_videos(self, video_url_or_urls, sample_indices_fn=None):
+    if isinstance(video_url_or_urls, list):
+        return list(zip(*[
+            _patched_fetch_videos(self, x, sample_indices_fn=sample_indices_fn)
+            for x in video_url_or_urls
+        ]))
+    return _load_video(video_url_or_urls, backend="pyav", sample_indices_fn=sample_indices_fn)
+
+video_processing_utils.BaseVideoProcessor.fetch_videos = _patched_fetch_videos
+```
+
+---
+
+## Timing benchmarks
+
+| Environment | GPU | Model | Tier | Load | Inference | Pass <60s? |
+|---|---|---|---|---|---|---|
+| Brev Hyperstack | H100 PCIe | CR2-2B | fps=2, 1M px | 1.7s | 44.1s | ✅ |
+| Brev Hyperstack | H100 PCIe | CR2-2B | fps=2, 1M px | 10.6s | 42.9s | ✅ |
+| Brev H100 | H100 | CR2-2B-FP8 | fps=8, 1M px | TBD | TBD | ⏳ pending smoke gate |
+| Brev H100 | H100 | CR2-8B-NVFP4 | fps=8, 1M px | TBD | TBD | ⏳ pending smoke gate |
+| Brev H100 | H100 | NIM 2B (NVCF) | 8 frames | N/A | TBD | ⏳ pending smoke gate |
+
+Notes:
+- "Inference" = preprocess + prefill + decode (TTFT-dominated for video inference)
+- CR2-8B fails the <60s target on all non-H100 GPUs tested; use CR2-2B for demos
+- FP8/NVFP4/NIM timing benchmarks TBD — update after smoke gate
+
+---
+
+## Dynamic Reconfiguration — Switching Model Class at Runtime
+
+**When invoked with `<instance> <model-class>` arguments**, the skill changes the active model without touching the static launch scripts.
+
+Usage:
+```
+/byo-video <instance-name> 8B
+/byo-video <instance-name> 2B
+/byo-video <user@host> 8B
+```
+
+### Models on disk (vLLM instance)
+
+| Size | Local path | HF ID |
+|---|---|---|
+| 2B FP8 | `~/cosmos-reason2/models/Cosmos-Reason2-2B-FP8` | `nvidia/Cosmos-Reason2-2B-FP8` |
+| 2B BF16 | `~/cosmos-reason2/models/Cosmos-Reason2-2B` | `nvidia/Cosmos-Reason2-2B` |
+| 8B NVFP4 | `~/cosmos-reason2/models/Cosmos-Reason2-8B-NVFP4` | `nvidia/Cosmos-Reason2-8B-NVFP4` |
+| 8B FP8 | `~/cosmos-reason2/models/Cosmos-Reason2-8B-FP8` | `nvidia/Cosmos-Reason2-8B-FP8` |
+| 8B BF16 | `~/cosmos-reason2/models/Cosmos-Reason2-8B` | `nvidia/Cosmos-Reason2-8B` |
+| 32B BF16 | public (May 2026) — no HF_TOKEN, ~66 GB | `nvidia/Cosmos-Reason2-32B` |
+| 32B AV | public (May 2026) — no HF_TOKEN, ~66 GB | `nvidia/Cosmos-Reason2-32B-AV` |
+
+### Reconfiguration procedure (agent runs all steps)
+
+**Step 1 — Kill Gradio:**
+```bash
+brev exec <instance> "pkill -f gradio_cr2_byo"
+```
+Then wait 3s, verify port is free:
+```bash
+brev exec <instance> "ss -tlnp | grep 7860"
+```
+
+**Step 2 — Kill vLLM server:**
+```bash
+brev exec <instance> "pkill -f 'vllm serve'"
+```
+Wait 5s for GPU memory to release:
+```bash
+brev exec <instance> "nvidia-smi --query-gpu=memory.used --format=csv,noheader"
+```
+
+**Step 3 — Deploy updated gradio script (if changed):**
+```bash
+B64=$(base64 -i ~/.claude/scripts/gradio_cr2_byo.py | tr -d '\n')
+brev exec <instance> "python3 -c \"import base64; open('/tmp/gradio_cr2_byo.py','wb').write(base64.b64decode('${B64}'))\""
+```
+
+**Step 4 — Start vLLM with target model:**
+
+For 2B FP8 (vLLM, real FP8 kernels):
+```bash
+brev exec <instance> "nohup bash -c 'source ~/.ngc_env && cd ~/cosmos-reason2 && .venv/bin/vllm serve models/Cosmos-Reason2-2B-FP8 --served-model-name nvidia/Cosmos-Reason2-2B-FP8 --port 8000 --dtype auto --trust-remote-code --max-model-len 8192 --gpu-memory-utilization 0.90 > /tmp/vllm_server.log 2>&1 &'"
+```
+
+For 8B NVFP4 (current default):
+```bash
+brev exec <instance> "nohup bash -c 'source ~/.ngc_env && cd ~/cosmos-reason2 && .venv/bin/vllm serve models/Cosmos-Reason2-8B-NVFP4 --served-model-name nvidia/Cosmos-Reason2-8B-NVFP4 --port 8000 --dtype auto --trust-remote-code --max-model-len 8192 --gpu-memory-utilization 0.85 > /tmp/vllm_server.log 2>&1 &'"
+```
+
+For 8B FP8:
+```bash
+brev exec <instance> "nohup bash -c 'source ~/.ngc_env && cd ~/cosmos-reason2 && .venv/bin/vllm serve models/Cosmos-Reason2-8B-FP8 --served-model-name nvidia/Cosmos-Reason2-8B-FP8 --port 8000 --dtype auto --trust-remote-code --max-model-len 8192 --gpu-memory-utilization 0.85 > /tmp/vllm_server.log 2>&1 &'"
+```
+
+For 32B BF16 (needs smaller max-model-len to fit 80GB — download first):
+```bash
+brev exec <instance> "nohup bash -c 'source ~/.ngc_env && cd ~/cosmos-reason2 && .venv/bin/vllm serve models/Cosmos-Reason2-32B --served-model-name nvidia/Cosmos-Reason2-32B --port 8000 --dtype bfloat16 --trust-remote-code --max-model-len 4096 --gpu-memory-utilization 0.95 > /tmp/vllm_server.log 2>&1 &'"
+```
+
+**Step 5 — Wait for vLLM ready (poll /v1/models, up to 120s):**
+```bash
+brev exec <instance> "for i in \$(seq 1 24); do curl -sf http://localhost:8000/v1/models && break || sleep 5; done"
+```
+
+**Step 6 — Start Gradio with correct MODEL_SIZE:**
+
+Do NOT edit `launch_gradio_vllm.sh`. Run inline:
+```bash
+brev exec <instance> "nohup bash -c 'source ~/.ngc_env && cd ~/cosmos-reason2 && INFERENCE_BACKEND=vllm VLLM_BASE_URL=http://localhost:8000/v1 MODEL_SIZE=<SIZE> .venv/bin/python /tmp/gradio_cr2_byo.py > /tmp/gradio_demo.log 2>&1 &'"
+```
+
+Replace `<SIZE>` with `2B`, `8B`, or `32B`.
+
+**Step 7 — Get URL:**
+```bash
+brev exec <instance> "sleep 20 && cat /tmp/gradio_url.txt"
+```
+
+### Downloading missing models
+
+If the target model isn't on disk yet, download before starting vLLM:
+```bash
+brev exec <instance> "cd ~/cosmos-reason2 && .venv/bin/huggingface-cli download nvidia/Cosmos-Reason2-8B-FP8 --local-dir models/Cosmos-Reason2-8B-FP8"
+```
+HF_TOKEN required for gated models. `Cosmos-Reason2-8B-FP8` is public.
+
+### 32B feasibility notes
+
+- **For /byo-video: H200 is the minimum viable GPU.** H100 single-GPU (80GB) is insufficient for comfortable inference under the skill's time constraints. Use `gpu-h200-sxm.1gpu-16vcpu-200gb` (141GB VRAM) — empirically confirmed with c3r-32b.
+- 32B BF16 weights are ~66GB, but vLLM requires additional VRAM for KV cache, activations, and overhead. On H100 80GB you can technically load with `--max-model-len 4096 --gpu-memory-utilization 0.95`, but this leaves almost no room for KV cache and will OOM on longer video sequences.
+- CR2-32B is **public** as of May 2026 — no HF_TOKEN required. Download: `huggingface-cli download nvidia/Cosmos-Reason2-32B --local-dir models/Cosmos-Reason2-32B`.
+- In vLLM mode with 8B loaded, `run_all_variants` will send 32B requests to the 8B server — the table `Notes` column will show `vLLM serves Cosmos-Reason2-8B-NVFP4` to flag the mismatch.
+- For true 32B benchmarking: restart vLLM with 32B model using this skill, then run `Run All Variants` with `MODEL_SIZE=32B`.
+
+---
+
+## Common failure modes
+
+| Symptom | Fix |
+|---|---|
+| Port 7860 unreachable | Check `ss -tlnp | grep 7860` on instance. If not listening, Gradio failed to start — check `/tmp/gradio_demo.log`. |
+| Video upload fails in browser | Gradio temp dir issue. Try with sample.mp4 via Examples button first. |
+| Black frames / torchcodec error | PyAV patch not applied. Confirm `gradio_cr2_byo.py` was deployed (not a custom script). |
+| OOM during inference | VRAM too low. Kill other GPU processes first. CR2-2B needs ~10GB GPU RAM peak. |
+| `uv sync --extra cu128` fails | Wrong CUDA driver. Check `nvidia-smi` shows CUDA 12.x driver. |
+| `claude auth status` → loggedIn: false | `claude auth login --console` (API users). On SSH: copy URL, open in local browser. |
+| Wrong VRAM tier selected (old Gradio using memory) | Setup script now kills port 7860 BEFORE measuring VRAM. Re-run setup to get clean tier. |
+| Inference >60s on high-VRAM workstation GPU | GPU name doesn't match H100/A100/H200/GB200 → fps=1 tier applies. If inference still slow, check that `GRADIO_FPS=1` is in the Gradio process env. |
+| HF 429 rate limit on download | Script retries 5× with 30s sleep. Common on shared cloud IPs. Usually succeeds by attempt 3-4. |
+| `brev login` fails with EOF | `brev login` requires a browser handoff — it cannot run in a non-TTY context. Open a separate terminal tab, run `brev login` there, complete the browser prompt, then return. |
+| vLLM Connection refused on first inference | `byo_video_setup.py` now auto-starts vLLM before Gradio (Step 9b). If running the Gradio script manually, start vLLM first: `nohup .venv/bin/vllm serve <model_dir> --port 8000 ... &` then poll `curl localhost:8000/v1/models`. |
+| Nemotron: `no module named 'mamba_ssm'` or `selective_scan_cuda` | vLLM PyPI build doesn't include mamba-ssm. Use vLLM nightly Docker: `vllm/vllm-openai:nightly-8bff831f0aa239006f34b721e63e1340e3472067` or `nvcr.io/nvidia/vllm:25.12.post1-py3`. |
+| Nemotron: `video_url not supported` or `unsupported content type` | vLLM version doesn't support `video_url` message type. Requires vLLM nightly; PyPI ≤0.11.0 unsupported. |
+| Nemotron: 400 error from vLLM on inference | Check that `--allowed-local-media-path /tmp` is in the vLLM serve command (set automatically by `byo_video_setup.py`). |

--- a/.claude/scripts/byo_video_runtime_monitor.py
+++ b/.claude/scripts/byo_video_runtime_monitor.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+"""
+byo_video_runtime_monitor.py — Runtime observer for /byo-video skill.
+
+Polls a remote Gradio host (via SSH) every POLL_INTERVAL seconds.
+Captures process health, GPU stats, log tail (since last offset),
+and detects errors via a rule catalog. Saves session metrics for
+later review.
+
+Usage:
+  poll    — long-running daemon (run via nohup)
+  status  — print current state JSON
+  alerts  — print alert stream (--since-line N to skip seen)
+  metrics — summarize inference history
+  stop    — kill the daemon via PID file
+
+Output (all local /tmp):
+  byo_video_runtime_state.json     — current snapshot
+  byo_video_runtime_alerts.jsonl   — append-only alerts
+  byo_video_session_metrics.jsonl  — append-only per-inference records
+  byo_video_runtime_monitor.log    — daemon's own log
+  byo_video_runtime_monitor.pid    — PID for stop
+"""
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+POLL_INTERVAL = 30
+LOG_TAIL_LINES = 400
+SSH_KEY = os.path.expanduser("~/.ssh/id_ed25519")
+SSH_TIMEOUT = 15
+HANG_THRESHOLD_S = int(os.environ.get("BYO_VIDEO_HANG_THRESHOLD_S", "180"))
+
+STATE_FILE   = Path("/tmp/byo_video_runtime_state.json")
+ALERTS_FILE  = Path("/tmp/byo_video_runtime_alerts.jsonl")
+METRICS_FILE = Path("/tmp/byo_video_session_metrics.jsonl")
+LOG_FILE     = Path("/tmp/byo_video_runtime_monitor.log")
+PID_FILE     = Path("/tmp/byo_video_runtime_monitor.pid")
+OFFSET_FILE  = Path("/tmp/byo_video_runtime_log_offset.json")
+
+ERROR_RULES = [
+    {
+        "name": "cuda_oom",
+        "patterns": [r"CUDA out of memory", r"OutOfMemoryError", r"torch\.cuda\.OutOfMemoryError"],
+        "severity": "critical",
+        "summary": "GPU ran out of memory during inference.",
+        "fix": "In Advanced Settings, lower GRADIO_MAX_PIXELS (try 65536 or 32768), shorten the video, or drop fps to 1.",
+    },
+    {
+        "name": "pyav_decode",
+        "patterns": [r"av\.error", r"InvalidDataError", r"Could not open video", r"Error reading video"],
+        "severity": "high",
+        "summary": "Video could not be decoded by PyAV.",
+        "fix": "Re-encode as MP4/H.264: ffmpeg -i input.mov -c:v libx264 -pix_fmt yuv420p output.mp4. Or try cosmos-reason2/data/sample.mp4.",
+    },
+    {
+        "name": "preprocess_empty",
+        "patterns": [r"IndexError.*preprocess", r"got 0 frames", r"empty video", r"sampled 0 frames", r"num_frames=0"],
+        "severity": "high",
+        "summary": "Video preprocessing returned 0 frames.",
+        "fix": "Lower fps in Advanced Settings, check the video is >1s and not corrupt, or try a different file.",
+    },
+    {
+        "name": "shape_mismatch",
+        "patterns": [r"size mismatch for", r"shape '.*' is invalid", r"RuntimeError.*shape", r"Expected size"],
+        "severity": "high",
+        "summary": "Tensor shape mismatch in model forward pass.",
+        "fix": "Re-select the checkpoint in Advanced Settings → Checkpoint dropdown. May be a partial model load.",
+    },
+    {
+        "name": "vllm_disconnect",
+        "patterns": [r"Connection refused.*8000", r"Connection refused.*vllm", r"vLLM .*not responding", r"ECONNREFUSED.*8000"],
+        "severity": "critical",
+        "summary": "Inference server not responding on port 8000 (vLLM or local NIM container).",
+        "fix": "If vLLM mode: ssh <host> 'pkill -f \"vllm serve\"' then restart Gradio. If NIM mode: ssh <host> 'docker ps -a | grep cosmos-nim' — if exited, ssh <host> 'docker logs --tail 100 cosmos-nim' for the failure reason, then re-run bash /tmp/nim_launch.sh <NGC_API_KEY>.",
+    },
+    {
+        "name": "nim_local_container_down",
+        "patterns": [r"\[NIM\] Container not responding at"],
+        "severity": "critical",
+        "summary": "Local NIM Docker container is not reachable from Gradio.",
+        "fix": "ssh <host> 'docker ps -a --filter name=cosmos-nim'; if container is Exited, run ssh <host> 'docker logs --tail 200 cosmos-nim' to see why; relaunch via ssh <host> 'bash /tmp/nim_launch.sh <NGC_API_KEY>'. Confirm port 8000 is mapped: ssh <host> 'curl -sf localhost:8000/v1/models'.",
+    },
+    {
+        "name": "nim_local_image_unauthorized",
+        "patterns": [r"unauthorized.*nvcr\.io", r"denied.*nvcr\.io", r"403.*nvcr\.io.*cosmos-reason2"],
+        "severity": "critical",
+        "summary": "NGC denied pull of cosmos-reason2 NIM image — key invalid or model not allowlisted.",
+        "fix": "Confirm NGC_API_KEY is current (nvapi- prefix), then 'docker login nvcr.io --username $oauthtoken --password-stdin'. If still denied, the model variant may require allowlisting via build.nvidia.com.",
+    },
+    {
+        # NIM-8B-FP8-THINK-EOS bug: greedy decode (temperature=0) on the FP8-quantized
+        # cosmos-reason2-8b NIM emits `<think>` then EOS, finishing in ≤3 tokens with no
+        # actual answer. Gradio shows the bare `<think>` opener and nothing else.
+        "name": "nim_local_think_eos_truncation",
+        "patterns": [r"\[vllm done\]\s+[\d.]+s\s+·\s+[123]\s+tok"],
+        "severity": "high",
+        "summary": "NIM 8B emitted only a few tokens — likely the <think>+EOS bug at greedy decode.",
+        "fix": "Raise temperature ≥ 0.3 in the Gradio Advanced Settings panel. The Gradio app already clamps internally for nim_local, but if the slider was force-pushed to 0 the bug returns. Confirm with: docker logs cosmos-nim 2>&1 | tail -20 and inspect the actual completion.",
+    },
+    {
+        "name": "process_killed",
+        "patterns": [r"out of memory: Killed process", r"oom-killer"],
+        "severity": "critical",
+        "summary": "A process was killed by the OOM killer (system RAM exhausted).",
+        "fix": "Free system RAM, reduce concurrent workloads, or use a host with more RAM. Setup needs a full restart.",
+    },
+    {
+        "name": "broken_pipe",
+        "patterns": [r"BrokenPipeError"],
+        "severity": "high",
+        "summary": "Gradio's stdout pipe broke — generator died mid-inference.",
+        "fix": "Stale gradio_cr2_byo.py on the remote. Redeploy from ~/.claude/scripts/gradio_cr2_byo.py.",
+    },
+    {
+        "name": "torch_compile_fail",
+        "patterns": [r"torch\._dynamo.*BackendCompilerFailed", r"CompilationError"],
+        "severity": "high",
+        "summary": "torch.compile failed during model load or first forward pass.",
+        "fix": "Set TORCH_COMPILE_DISABLE=1 and restart, or wait — first compile takes 2-5 min on 32B models.",
+    },
+    {
+        "name": "nim_api_error",
+        "patterns": [r"\[NIM ERROR\]"],
+        "severity": "high",
+        "summary": "NIM API call failed (NVCF endpoint).",
+        "fix": "Check NGC_API_KEY (must start with nvapi-), verify network can reach integrate.api.nvidia.com, confirm the model is in the NVCF catalog. NIM 2B = nvidia/cosmos-reason2-2b.",
+    },
+    {
+        "name": "vllm_runtime_error",
+        "patterns": [r"\[VLLM ERROR\]", r"\[vllm error\]"],
+        "severity": "high",
+        "summary": "vLLM inference call failed.",
+        "fix": "ssh <host> 'curl -sf localhost:8000/v1/models' to check vLLM. If down, restart it. Check /tmp/vllm_server.log on the remote for crash reason.",
+    },
+    {
+        "name": "generic_traceback",
+        "patterns": [r"^Traceback \(most recent call last\):"],
+        "severity": "medium",
+        "summary": "An unhandled exception was raised.",
+        "fix": "Read the full traceback in /tmp/gradio_demo.log on the remote.",
+    },
+]
+
+# Hang detection: temporal, not pattern-based. Inference is "started" when any of
+# these markers appears, "ended" when a completion or error marker appears.
+INFER_START_MARKERS = [
+    re.compile(r"\[infer\]\s+model="),       # HF backend kicks off
+    re.compile(r"\[vllm\]\s+endpoint="),     # vLLM backend kicks off
+    re.compile(r"\[nim\]\s+NGC_API_KEY"),    # NIM backend kicks off
+]
+INFER_END_MARKERS = [
+    re.compile(r"\[done\]\s+[\d.]+s"),        # HF success
+    re.compile(r"\[vllm done\]\s+[\d.]+s"),   # vLLM success
+    re.compile(r"\[nim done\]\s+[\d.]+s"),    # NIM success
+    re.compile(r"\[NIM ERROR\]"),             # NIM failure (counts as terminated)
+    re.compile(r"\[VLLM ERROR\]"),            # vLLM failure
+]
+
+# gradio_cr2_byo.py emits one of three completion lines per inference:
+#   HF backend:   "[done] 41.9s · 44 tok · ttft=15.08s"
+#   vLLM backend: "[vllm done] 30.5s · 287 tok out"
+#   NIM backend:  "[nim done] 12.3s · 156 tok out"
+# Plus a prefill marker: "[infer] Prefilling 297 tokens ..."
+HF_DONE_RE     = re.compile(r"\[done\]\s+([\d.]+)s\s+·\s+(\d+)\s+tok\s+·\s+ttft=([\d.]+)s")
+VLLM_DONE_RE   = re.compile(r"\[(vllm|nim) done\]\s+([\d.]+)s\s+·\s+(\d+)\s+tok")
+PREFILL_RE     = re.compile(r"\[infer\]\s+Prefilling\s+([\d,]+)\s+tokens")
+
+
+def ssh_exec(remote, cmd):
+    full = ["ssh", "-i", SSH_KEY, "-o", f"ConnectTimeout={SSH_TIMEOUT}",
+            "-o", "StrictHostKeyChecking=no", remote, cmd]
+    try:
+        r = subprocess.run(full, capture_output=True, text=True, timeout=SSH_TIMEOUT + 10)
+        return r.returncode, (r.stdout + r.stderr)
+    except subprocess.TimeoutExpired:
+        return -1, "<ssh timeout>"
+    except Exception as e:
+        return -1, f"<ssh error: {e}>"
+
+
+_OFFSET_DEFAULTS = {
+    "log_offset": 0,
+    "result_mtime": 0,
+    "last_infer_start_ts": 0,
+    "last_completion_ts": 0,
+    "hang_alert_fired_for_start_ts": 0,
+}
+
+
+def _load_offset_record(remote):
+    """Returns dict with all keys in _OFFSET_DEFAULTS. Migrates old bare-int schema."""
+    rec = dict(_OFFSET_DEFAULTS)
+    if not OFFSET_FILE.exists():
+        return rec
+    try:
+        d = json.loads(OFFSET_FILE.read_text())
+        stored = d.get(remote, 0)
+        if isinstance(stored, int):
+            rec["log_offset"] = stored
+        elif isinstance(stored, dict):
+            for k in _OFFSET_DEFAULTS:
+                if k in stored:
+                    rec[k] = stored[k]
+    except Exception:
+        pass
+    return rec
+
+
+def _save_offset_record(remote, **updates):
+    """Merge `updates` into the remote's offset record."""
+    rec = _load_offset_record(remote)
+    rec.update(updates)
+    d = {}
+    if OFFSET_FILE.exists():
+        try:
+            d = json.loads(OFFSET_FILE.read_text())
+        except Exception:
+            pass
+    d[remote] = rec
+    OFFSET_FILE.write_text(json.dumps(d))
+
+
+def load_offset(remote):
+    return _load_offset_record(remote)["log_offset"]
+
+
+def load_result_mtime(remote):
+    return _load_offset_record(remote)["result_mtime"]
+
+
+def save_offset(remote, offset):
+    _save_offset_record(remote, log_offset=offset)
+
+
+def save_result_mtime(remote, mtime):
+    _save_offset_record(remote, result_mtime=mtime)
+
+
+def append_alert(alert):
+    with ALERTS_FILE.open("a") as f:
+        f.write(json.dumps(alert) + "\n")
+
+
+def append_metric(metric):
+    with METRICS_FILE.open("a") as f:
+        f.write(json.dumps(metric) + "\n")
+
+
+def write_state(state):
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def log(msg):
+    with LOG_FILE.open("a") as f:
+        f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} {msg}\n")
+
+
+def detect_errors(new_log_text):
+    alerts = []
+    seen_rules = set()
+    lines = new_log_text.split("\n")
+    for rule in ERROR_RULES:
+        if rule["name"] in seen_rules:
+            continue
+        for pat in rule["patterns"]:
+            r = re.compile(pat)
+            for i, line in enumerate(lines):
+                if r.search(line):
+                    seen_rules.add(rule["name"])
+                    ctx_start = max(0, i - 3)
+                    ctx_end = min(len(lines), i + 4)
+                    context = "\n".join(lines[ctx_start:ctx_end])
+                    alerts.append({
+                        "ts": int(time.time()),
+                        "rule": rule["name"],
+                        "severity": rule["severity"],
+                        "summary": rule["summary"],
+                        "fix": rule["fix"],
+                        "trigger_line": line.strip()[:300],
+                        "context": context[:1200],
+                    })
+                    break
+            if rule["name"] in seen_rules:
+                break
+    return alerts
+
+
+def detect_inferences(new_log_text, session_id, model_id):
+    """Parse completed inferences from log text. Each [done]/[vllm done]/[nim done]
+    line yields one metric record. Prefill token count is carried from the most
+    recent [infer] Prefilling N tokens line. gen_s is computed as total - ttft
+    when ttft is available (HF backend only); otherwise null."""
+    metrics = []
+    pending_prefill = None
+    for line in new_log_text.split("\n"):
+        m_pre = PREFILL_RE.search(line)
+        if m_pre:
+            try:
+                pending_prefill = int(m_pre.group(1).replace(",", ""))
+            except Exception:
+                pending_prefill = None
+            continue
+        m_hf = HF_DONE_RE.search(line)
+        if m_hf:
+            total_s = float(m_hf.group(1))
+            tokens = int(m_hf.group(2))
+            ttft_s = float(m_hf.group(3))
+            metrics.append({
+                "ts": int(time.time()),
+                "session_id": session_id,
+                "model_id": model_id,
+                "backend": "hf",
+                "prefill_tokens": pending_prefill,
+                "total_s": total_s,
+                "ttft_s": ttft_s,
+                "gen_s": round(max(0.0, total_s - ttft_s), 2),
+                "tokens": tokens,
+            })
+            pending_prefill = None
+            continue
+        m_v = VLLM_DONE_RE.search(line)
+        if m_v:
+            metrics.append({
+                "ts": int(time.time()),
+                "session_id": session_id,
+                "model_id": model_id,
+                "backend": m_v.group(1),
+                "prefill_tokens": pending_prefill,
+                "total_s": float(m_v.group(2)),
+                "ttft_s": None,
+                "gen_s": None,
+                "tokens": int(m_v.group(3)),
+            })
+            pending_prefill = None
+    return metrics
+
+
+def to_int(s):
+    try:
+        return int(s.strip().split()[0])
+    except Exception:
+        return None
+
+
+def to_float(s):
+    try:
+        return float(s.strip().split()[0])
+    except Exception:
+        return None
+
+
+def count_lines(p):
+    if not p.exists():
+        return 0
+    try:
+        return sum(1 for _ in p.open())
+    except Exception:
+        return 0
+
+
+RESULT_JSON_PATH = "/tmp/byo_video_reason2_results.json"
+LOG_BYTE_CAP = 65536  # last 64KB of log per poll, max
+
+
+def poll_once(remote, rate, session_id, model_id):
+    # tail -c 65536 returns raw bytes from end-of-file (not lines). Combined
+    # with log_size and last_offset we slice the actual NEW bytes locally —
+    # avoids the duplicate-metric bug where detect_inferences re-fired on every
+    # [done] line in the tail each time log_size grew.
+    bundle = (
+        "echo '---PROCS---'; pgrep -af gradio_cr2_byo | head -3; "
+        "echo '---PORT---'; ss -tlnp 2>/dev/null | grep 7860 | head -1; "
+        "echo '---GPU---'; nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.free,memory.total,temperature.gpu,power.draw --format=csv,noheader,nounits 2>&1 | head -1; "
+        "echo '---LOGSIZE---'; stat -c %s /tmp/gradio_demo.log 2>/dev/null || echo 0; "
+        f"echo '---LOGTAIL---'; tail -c {LOG_BYTE_CAP} /tmp/gradio_demo.log 2>/dev/null; "
+        f"echo '---RESULT_MTIME---'; stat -c %Y {RESULT_JSON_PATH} 2>/dev/null || echo 0; "
+        f"echo '---RESULT---'; cat {RESULT_JSON_PATH} 2>/dev/null"
+    )
+    rc, out = ssh_exec(remote, bundle)
+    state = {
+        "ts": int(time.time()),
+        "remote": remote,
+        "rate_per_hour": rate,
+        "session_id": session_id,
+        "model_id": model_id,
+        "ssh_ok": rc == 0,
+        "gradio_alive": False,
+        "port_listening": False,
+        "gpu": {},
+        "log_size": 0,
+        "alerts_total": count_lines(ALERTS_FILE),
+        "metrics_total": count_lines(METRICS_FILE),
+    }
+    if rc != 0:
+        state["error"] = f"SSH failed (rc={rc}): {out[:500]}"
+        log(f"SSH failed: {out[:200]}")
+        write_state(state)
+        return state
+
+    sections = {}
+    cur = None
+    for line in out.split("\n"):
+        if line.startswith("---") and line.endswith("---"):
+            cur = line.strip("- ").strip()
+            sections[cur] = []
+        elif cur is not None:
+            sections[cur].append(line)
+    procs = "\n".join(sections.get("PROCS", []))
+    port = "\n".join(sections.get("PORT", []))
+    gpu_line = "\n".join(sections.get("GPU", [])).strip()
+    try:
+        log_size = int("\n".join(sections.get("LOGSIZE", [])).strip() or "0")
+    except Exception:
+        log_size = 0
+    log_tail = "\n".join(sections.get("LOGTAIL", []))
+
+    state["gradio_alive"] = "gradio_cr2_byo" in procs and bool(procs.strip())
+    state["port_listening"] = "LISTEN" in port and "7860" in port
+    state["log_size"] = log_size
+
+    parts = [p.strip() for p in gpu_line.split(",")]
+    if len(parts) >= 5:
+        state["gpu"] = {
+            "name": parts[0],
+            "util_pct": to_int(parts[1]),
+            "mem_used_mib": to_int(parts[2]),
+            "mem_free_mib": to_int(parts[3]),
+            "mem_total_mib": to_int(parts[4]),
+            "temp_c": to_int(parts[5]) if len(parts) > 5 else None,
+            "power_w": to_float(parts[6]) if len(parts) > 6 else None,
+        }
+
+    # Result JSON capture: gradio_cr2_byo writes the full result (prompt, response,
+    # timing, token counts, status) to /tmp/byo_video_reason2_results.json on each
+    # inference completion, OVERWRITING the previous result. We track its mtime so
+    # we only parse it when it advances. Pair it with the most recent log [done]
+    # line in this poll so prompt/response attach to the right metric record.
+    try:
+        result_mtime = int("\n".join(sections.get("RESULT_MTIME", [])).strip() or "0")
+    except Exception:
+        result_mtime = 0
+    result_text = "\n".join(sections.get("RESULT", [])).strip()
+    parsed_result = None
+    last_result_mtime = load_result_mtime(remote)
+    if result_mtime > last_result_mtime and result_text:
+        try:
+            parsed_result = json.loads(result_text)
+            save_result_mtime(remote, result_mtime)
+        except Exception as e:
+            log(f"result json parse failed: {e}")
+
+    last_offset = load_offset(remote)
+    # Slice only NEW bytes. log_tail is the last LOG_BYTE_CAP bytes from the
+    # remote; new_content is the suffix of that representing what was added
+    # since last poll. Truncation (log_size < last_offset) → reset to full tail.
+    new_content = ""
+    log_changed = False
+    if log_size > last_offset:
+        delta = log_size - last_offset
+        new_content = log_tail[-delta:] if len(log_tail) >= delta else log_tail
+        save_offset(remote, log_size)
+        log_changed = True
+    elif log_size < last_offset:
+        new_content = log_tail
+        save_offset(remote, log_size)
+        log_changed = True
+
+    if log_changed:
+        for a in detect_errors(new_content):
+            append_alert(a)
+            log(f"ALERT [{a['severity']}] {a['rule']}: {a['summary']}")
+            state["last_alert"] = a
+        new_metrics = detect_inferences(new_content, session_id, model_id)
+        if parsed_result and new_metrics:
+            new_metrics[-1]["prompt"] = (parsed_result.get("prompt") or "")[:2000]
+            new_metrics[-1]["response"] = (parsed_result.get("response") or "")[:8000]
+            new_metrics[-1]["status"] = parsed_result.get("status", "unknown")
+            # Fallback for prefill_tokens: if the [infer] Prefilling N tokens
+            # marker arrived in a different poll than the [done] marker (so
+            # detect_inferences's local pending_prefill was None), the result
+            # JSON's tokens_in field is authoritative.
+            if new_metrics[-1].get("prefill_tokens") is None:
+                tokens_in = parsed_result.get("tokens_in")
+                if tokens_in is not None:
+                    new_metrics[-1]["prefill_tokens"] = tokens_in
+            parsed_result = None  # consumed
+        for m in new_metrics:
+            append_metric(m)
+            ttft_str = f"{m['ttft_s']}s" if m.get('ttft_s') is not None else "n/a"
+            has_text = " +text" if m.get("response") else ""
+            log(f"INFER backend={m['backend']} total={m['total_s']}s ttft={ttft_str} tokens={m['tokens']}{has_text}")
+
+    # Result JSON updated but no [done] line in log window — synthesize a metric
+    # from the result JSON alone (covers the case where log offset already passed
+    # the [done] line in a prior poll, or log was truncated).
+    if parsed_result:
+        synth = {
+            "ts": int(time.time()),
+            "session_id": session_id,
+            "model_id": parsed_result.get("model") or model_id,
+            "backend": "from_result_json",
+            "prefill_tokens": parsed_result.get("tokens_in"),
+            "total_s": parsed_result.get("infer_time_s"),
+            "ttft_s": parsed_result.get("ttft_s"),
+            "gen_s": None,
+            "tokens": parsed_result.get("tokens_out"),
+            "prompt": (parsed_result.get("prompt") or "")[:2000],
+            "response": (parsed_result.get("response") or "")[:8000],
+            "status": parsed_result.get("status", "unknown"),
+        }
+        append_metric(synth)
+        log(f"INFER (from result json) tokens_out={synth['tokens']} ttft={synth['ttft_s']}s")
+
+    if not state["gradio_alive"] and last_offset > 0:
+        a = {
+            "ts": int(time.time()),
+            "rule": "process_disappeared",
+            "severity": "critical",
+            "summary": "Gradio process is no longer running.",
+            "fix": "Re-run /byo-video to restart, or manually relaunch Gradio. Check /tmp/gradio_demo.log on remote for the crash reason.",
+            "trigger_line": "(no gradio_cr2_byo PID found)",
+            "context": "",
+        }
+        append_alert(a)
+        state["last_alert"] = a
+        log("ALERT: gradio_cr2_byo process disappeared")
+
+    # ── Hang detection (temporal) ─────────────────────────────────────────────
+    # If we observe a backend start marker but no end marker has arrived within
+    # HANG_THRESHOLD_S, fire one inference_hung alert. Resets when next
+    # completion lands.
+    rec = _load_offset_record(remote)
+    last_start_ts = rec["last_infer_start_ts"]
+    last_end_ts   = rec["last_completion_ts"]
+    last_alerted_for = rec["hang_alert_fired_for_start_ts"]
+    now = int(time.time())
+
+    if log_changed and new_content:
+        saw_start = any(p.search(new_content) for p in INFER_START_MARKERS)
+        saw_end   = any(p.search(new_content) for p in INFER_END_MARKERS)
+        if saw_start and now > last_start_ts:
+            last_start_ts = now
+            _save_offset_record(remote, last_infer_start_ts=last_start_ts)
+        if saw_end:
+            last_end_ts = now
+            _save_offset_record(remote, last_completion_ts=last_end_ts)
+
+    state["last_infer_start_ts"] = last_start_ts
+    state["last_completion_ts"]  = last_end_ts
+
+    if last_start_ts > last_end_ts:
+        elapsed_since_start = now - last_start_ts
+        state["pending_inference_s"] = elapsed_since_start
+        if elapsed_since_start > HANG_THRESHOLD_S and last_alerted_for != last_start_ts:
+            a = {
+                "ts": now,
+                "rule": "inference_hung",
+                "severity": "high",
+                "summary": f"Inference started {elapsed_since_start}s ago but no completion observed.",
+                "fix": "Likely network or API hang (NIM mode without reachable integrate.api.nvidia.com, vLLM not responding, or stuck preprocess). Check the latest backend marker in /tmp/gradio_demo.log on remote, kill the Gradio process, and relaunch.",
+                "trigger_line": f"(no [done]/[vllm done]/[nim done] within {HANG_THRESHOLD_S}s of last [infer]/[vllm]/[nim] start marker)",
+                "context": log_tail[-1000:],
+            }
+            append_alert(a)
+            state["last_alert"] = a
+            _save_offset_record(remote, hang_alert_fired_for_start_ts=last_start_ts)
+            log(f"ALERT: inference_hung — {elapsed_since_start}s since last start, no completion")
+
+    state["alerts_total"] = count_lines(ALERTS_FILE)
+    state["metrics_total"] = count_lines(METRICS_FILE)
+    write_state(state)
+    return state
+
+
+def cmd_poll(args):
+    PID_FILE.write_text(str(os.getpid()))
+
+    def _stop(signum, frame):
+        log(f"signal {signum} received, exiting")
+        try:
+            PID_FILE.unlink()
+        except Exception:
+            pass
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    log(f"runtime monitor started (pid={os.getpid()}, remote={args.remote}, rate=${args.rate}/hr, session={args.session_id})")
+    try:
+        while True:
+            try:
+                poll_once(args.remote, args.rate, args.session_id or args.remote, args.model_id or "unknown")
+            except Exception as e:
+                log(f"poll error: {e}")
+            time.sleep(POLL_INTERVAL)
+    finally:
+        try:
+            PID_FILE.unlink()
+        except Exception:
+            pass
+
+
+def cmd_status(args):
+    if not STATE_FILE.exists():
+        print("No state file. Is the runtime monitor running?")
+        sys.exit(1)
+    print(STATE_FILE.read_text())
+
+
+def cmd_alerts(args):
+    if not ALERTS_FILE.exists():
+        print("No alerts.")
+        return
+    lines = ALERTS_FILE.read_text().splitlines()
+    start = max(0, args.since_line)
+    if start >= len(lines):
+        return
+    for i, line in enumerate(lines[start:], start=start):
+        try:
+            a = json.loads(line)
+            print(f"[{i}] {a.get('severity','?').upper():9s}  {a.get('rule','?'):25s}  {a.get('summary','?')}")
+            if args.verbose:
+                print(f"      fix: {a.get('fix','')}")
+                if a.get("trigger_line"):
+                    print(f"      trigger: {a['trigger_line']}")
+        except Exception:
+            pass
+
+
+def cmd_metrics(args):
+    if not METRICS_FILE.exists():
+        print("No metrics.")
+        return
+    lines = METRICS_FILE.read_text().splitlines()
+    print(f"Total inferences: {len(lines)}")
+    if not lines:
+        return
+    totals, ttfts, gens, toks = [], [], [], []
+    by_backend = {}
+    for line in lines:
+        try:
+            m = json.loads(line)
+            totals.append(m.get("total_s", 0))
+            if m.get("ttft_s") is not None:
+                ttfts.append(m["ttft_s"])
+            if m.get("gen_s") is not None:
+                gens.append(m["gen_s"])
+            toks.append(m.get("tokens", 0))
+            by_backend[m.get("backend", "?")] = by_backend.get(m.get("backend", "?"), 0) + 1
+        except Exception:
+            pass
+    if totals:
+        print(f"By backend: {by_backend}")
+        print(f"Total min/avg/max: {min(totals):.2f}s / {sum(totals)/len(totals):.2f}s / {max(totals):.2f}s")
+        if ttfts:
+            print(f"TTFT  min/avg/max: {min(ttfts):.2f}s / {sum(ttfts)/len(ttfts):.2f}s / {max(ttfts):.2f}s  (n={len(ttfts)})")
+        if gens:
+            print(f"Gen   min/avg/max: {min(gens):.2f}s / {sum(gens)/len(gens):.2f}s / {max(gens):.2f}s  (n={len(gens)})")
+        print(f"Tokens min/avg/max: {min(toks)} / {sum(toks)//len(toks)} / {max(toks)}")
+
+
+def cmd_stop(args):
+    if not PID_FILE.exists():
+        print("Not running (no PID file).")
+        return
+    try:
+        pid = int(PID_FILE.read_text().strip())
+        os.kill(pid, signal.SIGTERM)
+        print(f"Sent SIGTERM to {pid}")
+    except Exception as e:
+        print(f"Stop failed: {e}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Runtime monitor for /byo-video skill")
+    sp = p.add_subparsers(dest="cmd", required=True)
+
+    pp = sp.add_parser("poll", help="Run polling daemon (use nohup)")
+    pp.add_argument("--remote", required=True, help="user@host SSH target")
+    pp.add_argument("--rate", type=float, default=0.0, help="$/hr cost (0 for self-hosted SSH targets)")
+    pp.add_argument("--session-id", default=None)
+    pp.add_argument("--model-id", default=None)
+    pp.set_defaults(func=cmd_poll)
+
+    sp.add_parser("status", help="Print current state JSON").set_defaults(func=cmd_status)
+    sp.add_parser("stop", help="Stop the daemon via PID file").set_defaults(func=cmd_stop)
+
+    pa = sp.add_parser("alerts", help="Print alert stream")
+    pa.add_argument("--since-line", type=int, default=0)
+    pa.add_argument("--verbose", "-v", action="store_true")
+    pa.set_defaults(func=cmd_alerts)
+
+    sp.add_parser("metrics", help="Summarize inference history").set_defaults(func=cmd_metrics)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/byo_video_setup.py
+++ b/.claude/scripts/byo_video_setup.py
@@ -1,0 +1,931 @@
+#!/usr/bin/env python3
+"""
+Cosmos BYO Video Demo setup + launch.
+Version: 2026-04-30
+Canonical source: ~/.claude/scripts/byo_video_setup.py
+
+Runs on the GPU instance. Prints live progress with ETAs.
+MODEL_SIZE-driven: downloads all variants for the selected model size.
+At the end, prints a clickable OSC 8 hyperlink to the Gradio URL.
+URL is also written to /tmp/gradio_url.txt for agent capture.
+
+Env vars:
+  HF_TOKEN          — required for gated model download (checks ~/.cache/huggingface/token if not set)
+  NGC_API_KEY       — required for NIM mode (nvapi-... prefix, 8B only; not needed for Cosmos3)
+  MODEL_SIZE        — 2B | 8B | 32B | C3-2B | C3-8B | C3-32B | C3-super | NEM-12B | QW3-2B | QW3-8B | QW3-32B  (default: C3-2B)
+  MODEL_DIR         — override local download path for primary model
+  GRADIO_PORT       — port for Gradio (default: 7860)
+  SKIP_HF_PRELOAD   — set to 1 to skip HF model preload at Gradio startup (auto in vLLM mode)
+  VLLM_MAX_MODEL_LEN — max context length for vLLM (default: 32768; do not reduce below 32768 for video)
+"""
+import os, sys, time, subprocess, re, shutil, json, urllib.request, socket
+
+# ── ANSI helpers ────────────────────────────────────────────────────────────
+GREEN  = "\033[32m"
+YELLOW = "\033[33m"
+CYAN   = "\033[36m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+RESET  = "\033[0m"
+
+def ok(msg):     print(f"  {GREEN}✓{RESET}  {msg}", flush=True)
+def run(msg):    print(f"  {YELLOW}⟳{RESET}  {msg}", flush=True)
+def info(msg):   print(f"  {CYAN}→{RESET}  {msg}", flush=True)
+def warn(msg):   print(f"  {YELLOW}⚠{RESET}  {msg}", flush=True)
+def header(msg, eta=None):
+    eta_str = f"  {DIM}[est. {eta}]{RESET}" if eta else ""
+    print(f"\n{BOLD}{msg}{RESET}{eta_str}", flush=True)
+
+def hyperlink(url, label=None):
+    label = label or url
+    return f"\033]8;;{url}\033\\{BOLD}{CYAN}{label}{RESET}\033]8;;\033\\"
+
+def run_cmd(args, cwd=None, env=None, timeout=None):
+    try:
+        result = subprocess.run(
+            args, cwd=cwd, env=env, timeout=timeout,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
+        return result.returncode, result.stdout
+    except FileNotFoundError:
+        return 1, f"command not found: {args[0]}"
+    except subprocess.TimeoutExpired:
+        return 1, "timeout"
+
+def stream_cmd(args, cwd=None, env=None, prefix=""):
+    proc = subprocess.Popen(
+        args, cwd=cwd, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    for line in proc.stdout:
+        line = line.rstrip()
+        if line:
+            print(f"     {DIM}{prefix}{line}{RESET}", flush=True)
+    proc.wait()
+    return proc.returncode
+
+# ── Size-driven model config (mirrors gradio_cr2_byo.py MODEL_CONFIGS) ───────
+_MODEL_CONFIGS = {
+    # ── Cosmos3-Reasoner (C3-2B/C3-32B/C3-super gated; C3-8B = Cosmos3-Nano-Reasoner, public) ──
+    "C3-2B": {
+        "variants": [
+            ("C3R-2B BF16", "Cosmos3-Reasoner-2B", "nvidia/Cosmos3-Reasoner-2B-Private", "~TBD"),
+        ],
+        "nim": None,
+    },
+    "C3-8B": {
+        "variants": [
+            ("C3R-Nano BF16", "Cosmos3-Nano-Reasoner", "nvidia/Cosmos3-Nano-Reasoner", "~TBD"),
+        ],
+        "nim": None,
+    },
+    "C3-32B": {
+        "variants": [
+            ("C3R-32B BF16", "Cosmos3-Reasoner-32B", "nvidia/Cosmos3-Reasoner-32B-Private", "~TBD"),
+        ],
+        "nim": None,
+        # disk_gb: 1024 (1TB minimum — Alex explicit requirement for 32B)
+        "disk_gb": 1024,
+        # vLLM flags: tensor-parallel-size 1 + high memory utilization for single H100 80GB.
+        # NOTE: weight size unverified (25 safetensor files, estimate ~60-70GB BF16).
+        # If weights exceed ~72GB, OOM will occur — flag for review before production deploy.
+        "vllm_extra_flags": ["--tensor-parallel-size", "1", "--gpu-memory-utilization", "0.93"],
+    },
+    "C3-super": {
+        "variants": [
+            ("C3-Super BF16", "Cosmos3-Super-Reasoner", "nvidia/Cosmos3-Super-Reasoner", "~TBD"),
+        ],
+        "nim": None,
+        # 32B model — requires H200 SXM 141GB (confirmed from live deployment 2026-05-05).
+        "disk_gb": 1024,
+        # Architecture: NemotronVLForConditionCausalLM. vLLM may raise "Unsupported architecture"
+        # if this arch is not registered in the installed vLLM build. Use INFERENCE_BACKEND=hf
+        # as a fallback — confirmed working on H200 at 2026-05-05 live run.
+        "vllm_extra_flags": ["--tensor-parallel-size", "1", "--gpu-memory-utilization", "0.93"],
+    },
+    # ── Cosmos Reason2 ──
+    "2B": {
+        "variants": [
+            ("CR2-2B BF16", "Cosmos-Reason2-2B",     "nvidia/Cosmos-Reason2-2B",     "~4 GB"),
+            ("CR2-2B FP8",  "Cosmos-Reason2-2B-FP8", "nvidia/Cosmos-Reason2-2B-FP8", "~2 GB"),
+        ],
+        "nim": None,
+    },
+    "8B": {
+        "variants": [
+            ("CR2-8B BF16",  "Cosmos-Reason2-8B",       "nvidia/Cosmos-Reason2-8B",       "~16 GB"),
+            ("CR2-8B NVFP4", "Cosmos-Reason2-8B-NVFP4", "nvidia/Cosmos-Reason2-8B-NVFP4", "~4 GB"),
+        ],
+        "nim": "nvidia/cosmos-reason2-8b",
+    },
+    "32B": {
+        "variants": [
+            ("CR2-32B BF16", "Cosmos-Reason2-32B",    "nvidia/Cosmos-Reason2-32B",    "~66 GB"),
+            ("CR2-32B AV",   "Cosmos-Reason2-32B-AV", "nvidia/Cosmos-Reason2-32B-AV", "~66 GB"),
+        ],
+        "nim": None,
+        # 33B params × 2 bytes BF16 = ~66GB weights. On H100 80GB: use 0.95 utilization.
+        # KV cache budget is ~4GB at this utilization — reduce max-model-len accordingly.
+        "vllm_extra_flags": ["--gpu-memory-utilization", "0.95"],
+        "vllm_max_model_len": 4096,
+    },
+    # ── Qwen3-VL (public — no HF_TOKEN required) ────────────────────────────────
+    # vLLM-only: uses video_url content type with file:// path (same as Nemotron).
+    # Frame control via extra_body mm_processor_kwargs at inference time.
+    # Variants: 2B fits 1x H100; 8B fits 1x H100 80GB; 32B needs TP=2 or FP8 on 1x H100.
+    "QW3-2B": {
+        "variants": [
+            ("Qwen3-VL-2B Instruct",    "Qwen3-VL-2B-Instruct",     "Qwen/Qwen3-VL-2B-Instruct",     "~5 GB"),
+            ("Qwen3-VL-2B FP8",         "Qwen3-VL-2B-Instruct-FP8", "Qwen/Qwen3-VL-2B-Instruct-FP8", "~3 GB"),
+            ("Qwen3-VL-2B Thinking",    "Qwen3-VL-2B-Thinking",     "Qwen/Qwen3-VL-2B-Thinking",     "~5 GB"),
+        ],
+        "nim": None,
+        "vllm_extra_flags": ["--gpu-memory-utilization", "0.85", "--allowed-local-media-path", "/tmp"],
+        "vllm_max_model_len": 32768,
+    },
+    "QW3-8B": {
+        "variants": [
+            ("Qwen3-VL-8B Instruct",    "Qwen3-VL-8B-Instruct",     "Qwen/Qwen3-VL-8B-Instruct",     "~16 GB"),
+            ("Qwen3-VL-8B FP8",         "Qwen3-VL-8B-Instruct-FP8", "Qwen/Qwen3-VL-8B-Instruct-FP8", "~9 GB"),
+            ("Qwen3-VL-8B Thinking",    "Qwen3-VL-8B-Thinking",     "Qwen/Qwen3-VL-8B-Thinking",     "~16 GB"),
+        ],
+        "nim": None,
+        "vllm_extra_flags": ["--gpu-memory-utilization", "0.85", "--allowed-local-media-path", "/tmp"],
+        "vllm_max_model_len": 32768,
+    },
+    "QW3-32B": {
+        "variants": [
+            ("Qwen3-VL-32B Instruct",   "Qwen3-VL-32B-Instruct",     "Qwen/Qwen3-VL-32B-Instruct",     "~64 GB"),
+            ("Qwen3-VL-32B FP8",        "Qwen3-VL-32B-Instruct-FP8", "Qwen/Qwen3-VL-32B-Instruct-FP8", "~33 GB"),
+            ("Qwen3-VL-32B Thinking",   "Qwen3-VL-32B-Thinking",     "Qwen/Qwen3-VL-32B-Thinking",     "~64 GB"),
+        ],
+        "nim": None,
+        "vllm_extra_flags": ["--gpu-memory-utilization", "0.93", "--allowed-local-media-path", "/tmp"],
+        "vllm_max_model_len": 16384,
+    },
+    # ── Nemotron-Nano-12B-v2-VL (gated — HF_TOKEN with nvidia org required) ──────
+    # Requires vLLM nightly or compatible build; PyPI vLLM ≤0.11.0 unsupported.
+    # Uses opencv video backend (not PyAV). Gradio sends video as file:// URL.
+    # NVFP4-QAD variant requires special vLLM build — use BF16 or FP8 for demos.
+    "NEM-12B": {
+        "variants": [
+            ("Nem-12B BF16", "NVIDIA-Nemotron-Nano-12B-v2-VL-BF16", "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16", "~26 GB"),
+            ("Nem-12B FP8",  "NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",  "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",  "~13 GB"),
+        ],
+        "nim": None,
+        "vllm_extra_flags": [
+            "--media-io-kwargs", '{"video": {"fps": 2, "num_frames": 128}}',
+            "--video-pruning-rate", "0.75",
+            "--allowed-local-media-path", "/tmp",
+        ],
+        "vllm_max_model_len": 32768,
+        # VLLM_VIDEO_LOADER_BACKEND=opencv: required for Nemotron video decoding.
+        # Nemotron's vLLM integration does not support PyAV; opencv is the only supported backend.
+        # FLASHINFER_DISABLE_VERSION_CHECK=1: bypasses mismatch between flashinfer Python package
+        # (0.5.3) and flashinfer-cubin (0.6.8.post1) installed by cosmos-reason2 uv sync.
+        "vllm_env": {
+            "VLLM_VIDEO_LOADER_BACKEND": "opencv",
+            "FLASHINFER_DISABLE_VERSION_CHECK": "1",
+        },
+    },
+}
+
+# ── Config ──────────────────────────────────────────────────────────────────
+HOME          = os.path.expanduser("~")
+PATH_EXTRA    = f"{HOME}/.local/bin:{HOME}/.cargo/bin"
+# HF_HOME=/tmp/hf-home: avoids root-owned ~/.cache/huggingface/ on Brev/shadeform instances.
+# byo_video_setup.py may run as a non-root user where ~/.cache is owned by root (prior root
+# invocation). Redirecting to /tmp/hf-home ensures write access for model cache, frpc binary,
+# and HF modules. Set early so all downstream ENV copies inherit it.
+HF_HOME_DIR   = os.environ.get("HF_HOME", "/tmp/hf-home")
+os.makedirs(HF_HOME_DIR, exist_ok=True)
+ENV           = {**os.environ, "PATH": f"{PATH_EXTRA}:{os.environ.get('PATH', '')}",
+                 "PYTHONUNBUFFERED": "1",
+                 "HF_HOME": HF_HOME_DIR,
+                 "HF_MODULES_CACHE": f"{HF_HOME_DIR}/modules"}
+HF_TOKEN      = os.environ.get("HF_TOKEN", "")
+NGC_API_KEY   = os.environ.get("NGC_API_KEY", "")
+MODEL_SIZE    = os.environ.get("MODEL_SIZE", "C3-2B").upper()
+# .upper() normalises input but breaks mixed-case keys. Remap known exceptions.
+_MODEL_SIZE_FIX = {"C3-SUPER": "C3-super"}
+MODEL_SIZE = _MODEL_SIZE_FIX.get(MODEL_SIZE, MODEL_SIZE)
+# Cosmos3-Reasoner uses cosmos-reason2 working dir until a dedicated repo is published.
+# Set COSMOS_DIR env var to override if the repo path changes.
+REASON2_DIR   = os.environ.get("COSMOS_DIR", f"{HOME}/cosmos-reason2")
+MODELS_BASE   = f"{REASON2_DIR}/models"
+GRADIO_PORT   = int(os.environ.get("GRADIO_PORT", "7860"))
+GRADIO_APP    = "/tmp/gradio_cr2_byo.py"
+URL_FILE      = "/tmp/gradio_url.txt"
+LOG_FILE      = "/tmp/gradio_demo.log"
+# MAXLEN-001: 32768 is the minimum required for video queries. Do not reduce below this.
+VLLM_MAX_MODEL_LEN   = int(os.environ.get("VLLM_MAX_MODEL_LEN", "32768"))
+INFERENCE_BACKEND    = os.environ.get("INFERENCE_BACKEND", "hf")
+# VRAM flags — set during GPU detection; declare defaults here
+ULTRA_LOW_VRAM = False
+LOW_VRAM       = False
+# Cost tracking
+BREV_RATE_PER_HOUR = float(os.environ.get("BREV_RATE_PER_HOUR", "0"))
+SETUP_START        = time.time()
+
+def credits_spent():
+    if BREV_RATE_PER_HOUR <= 0:
+        return ""
+    elapsed = time.time() - SETUP_START
+    cost = BREV_RATE_PER_HOUR * elapsed / 3600
+    return f" | Credits: ${cost:.3f}"
+
+if MODEL_SIZE not in _MODEL_CONFIGS:
+    print(f"  ✗  MODEL_SIZE={MODEL_SIZE} not supported. Use C3-2B, C3-8B, C3-32B, 2B, 8B, 32B, NEM-12B, QW3-2B, QW3-8B, or QW3-32B.")
+    sys.exit(1)
+
+_cfg = _MODEL_CONFIGS[MODEL_SIZE]
+
+# Primary variant (first in list) drives MODEL_DIR/MODEL_NAME defaults
+_primary_label, _primary_dirname, _primary_hf_id, _ = _cfg["variants"][0]
+MODEL_DIR  = os.environ.get("MODEL_DIR",  f"{MODELS_BASE}/{_primary_dirname}")
+MODEL_NAME = _primary_hf_id
+
+# ── MODEL_ID override (arbitrary HF model, bypasses MODEL_SIZE lookup) ───────
+MODEL_ID = os.environ.get("MODEL_ID", "")
+if MODEL_ID:
+    MODEL_NAME = MODEL_ID
+    # Only fall back to "custom" if MODEL_SIZE wasn't explicitly set to a known config key.
+    # Prevents MODEL_ID from silently discarding a valid MODEL_SIZE (e.g. NEM-12B, C3-8B).
+    if MODEL_SIZE not in _MODEL_CONFIGS:
+        # Unknown size: derive directory name from MODEL_ID. Keep hyphens — Linux supports them.
+        _model_dir_name = MODEL_ID.split("/")[-1]
+        MODEL_DIR  = os.path.join(MODELS_BASE, _model_dir_name)
+        MODEL_SIZE = "custom"
+        # Estimate size hint from model ID
+        _size_hint = "~8GB" if "8B" in MODEL_ID else "~16GB" if ("32B" in MODEL_ID or "14B" in MODEL_ID) else "~4GB"
+        # Override _cfg to a minimal single-variant config
+        _cfg = {
+            "repo": MODEL_ID.split("/")[-1],
+            "variants": [(_model_dir_name, _model_dir_name, MODEL_ID, _size_hint)],
+            "nim": False,
+        }
+        _variant_labels = MODEL_ID
+    # When MODEL_SIZE is a known config key: MODEL_DIR already set correctly from config.
+    # Only MODEL_NAME is updated to the explicit MODEL_ID override.
+
+# ── Dashboard: 9-step progress checklist ─────────────────────────────────────
+STEP_LABELS = [
+    "GPU detect + VRAM tier",
+    "HF auth + token validate",
+    "NGC API key",
+    "uv install",
+    "cosmos-reason2 repo",
+    "uv sync + CUDA libs",
+    "PyAV + Gradio + requests",
+    "Model weights download",
+    "Gradio launch",
+]
+STEPS_DONE = []
+
+def print_dashboard():
+    print("\n── Setup Progress ──────────────────────────────", flush=True)
+    elapsed = int(time.time() - SETUP_START)
+    print(f"  Elapsed: {elapsed//60}m {elapsed%60}s{credits_spent()}", flush=True)
+    for i, label in enumerate(STEP_LABELS, 1):
+        if i in STEPS_DONE:
+            marker = "✅"
+        elif i == (max(STEPS_DONE) + 1 if STEPS_DONE else 1):
+            marker = "⟳ "
+        else:
+            marker = "—"
+        print(f"  [{marker}] Step {i}: {label}", flush=True)
+    print("────────────────────────────────────────────────\n", flush=True)
+
+print_dashboard()
+
+# ── Pre-step: kill old Gradio so VRAM measurement is accurate ────────────────
+subprocess.run(["bash", "-c", f"fuser -k {GRADIO_PORT}/tcp 2>/dev/null || true"])
+time.sleep(2)
+
+# ── Step 1: GPU check ─────────────────────────────────────────────────────────
+header("Step 1 — GPU detect", eta="<5s")
+NVIDIA_SMI_RETRIES = 3
+_smi_rc = 1
+_smi_out = ""
+for _attempt in range(NVIDIA_SMI_RETRIES):
+    _smi_rc, _smi_out = run_cmd(
+        ["nvidia-smi", "--query-gpu=name,memory.free,memory.total",
+         "--format=csv,noheader,nounits"]
+    )
+    if _smi_rc == 0 and _smi_out.strip():
+        break
+    if _attempt < NVIDIA_SMI_RETRIES - 1:
+        warn(f"nvidia-smi attempt {_attempt + 1} failed — retrying in 5s")
+        time.sleep(5)
+else:
+    if _smi_rc != 0 or not _smi_out.strip():
+        warn("nvidia-smi failed after 3 attempts — defaulting to LOW_VRAM tier")
+        gpu_name   = "unknown"
+        vram_free  = 0
+        vram_total = 0
+        LOW_VRAM   = True
+        tier_name  = "low-VRAM (fallback)"
+        gradio_fps = 4
+        max_pixels = 131072
+        prefill_tps = 15
+
+if _smi_rc == 0 and _smi_out.strip():
+    gpu_line   = _smi_out.strip().splitlines()[0]
+    parts_     = [p.strip() for p in gpu_line.split(",")]
+    gpu_name   = parts_[0]
+    vram_free  = int(parts_[1].split()[0])
+    vram_total = int(parts_[2].split()[0])
+
+    _gpu_upper  = gpu_name.upper()
+    _h100_class = any(tag in _gpu_upper for tag in ("H100", "A100", "H200", "GB200"))
+    if _h100_class and vram_free >= 60000:
+        tier_name   = "H100/A100"
+        gradio_fps  = 8
+        max_pixels  = 1048576
+        prefill_tps = 90
+    elif vram_free >= 40000:
+        tier_name   = "high-VRAM"
+        gradio_fps  = 8
+        max_pixels  = 524288
+        prefill_tps = 23
+    elif vram_free >= 8000:
+        tier_name   = "low-VRAM (<40GB)"
+        gradio_fps  = 4
+        max_pixels  = 131072
+        prefill_tps = 15
+        LOW_VRAM    = True
+    else:
+        LOW_VRAM       = True
+        ULTRA_LOW_VRAM = True
+        gradio_fps     = 1
+        max_pixels     = 65536
+        prefill_tps    = 10
+        tier_name      = "ULTRA-LOW-VRAM"
+
+if ULTRA_LOW_VRAM:
+    warn("RTX consumer GPU detected (<8GB VRAM free). Demo will run but may OOM on videos >5s at 720p. Pre-resize to 360p before upload.")
+
+if not MODEL_ID:
+    _variant_labels = " → ".join(lbl for lbl, _, _, _ in _cfg["variants"])
+    if _cfg.get("nim"):
+        _variant_labels += f" → NIM-{MODEL_SIZE}"
+else:
+    _variant_labels = MODEL_ID
+
+ok(f"{gpu_name}  {vram_free:,} MiB free / {vram_total:,} MiB total")
+ok(f"MODEL_SIZE: {MODEL_SIZE}  |  variants: {_variant_labels}")
+ok(f"VRAM tier: {tier_name}  |  fps={gradio_fps}, max_pixels={max_pixels:,}, prefill_tps={prefill_tps}")
+STEPS_DONE.append(1)
+print_dashboard()
+
+# ── Step 2: HF token ──────────────────────────────────────────────────────────
+header("Step 2 — HuggingFace auth", eta="<5s")
+hf_cache = os.path.expanduser("~/.cache/huggingface/token")
+if INFERENCE_BACKEND == "nim_local":
+    info("nim_local backend — HF auth not required (NIM container ships the model). Skipping Step 2/2b.")
+elif HF_TOKEN:
+    ok(f"HF_TOKEN set ({len(HF_TOKEN)} chars)")
+elif os.path.exists(hf_cache):
+    ok(f"HF token found at ~/.cache/huggingface/token")
+    with open(hf_cache) as f:
+        HF_TOKEN = f.read().strip()
+    ENV["HF_TOKEN"] = HF_TOKEN
+else:
+    print("  ✗  HF_TOKEN not set and no cached token found.")
+    print("     Run: export HF_TOKEN=hf_... and re-run this script.")
+    sys.exit(1)
+
+# ── Step 2b: Validate HF token ────────────────────────────────────────────────
+if INFERENCE_BACKEND != "nim_local":
+    header("Step 2b — Validate HF token", eta="<2s")
+    _hf_req = urllib.request.Request(
+        "https://huggingface.co/api/whoami",
+        headers={"Authorization": f"Bearer {HF_TOKEN}"}
+    )
+    try:
+        with urllib.request.urlopen(_hf_req, timeout=10) as _resp:
+            if _resp.status == 200:
+                ok("HF token valid")
+            else:
+                print(f"  ✗  HF token returned HTTP {_resp.status} — run 'huggingface-cli login' on this instance")
+                sys.exit(1)
+    except Exception as _hf_err:
+        warn(f"HF token check failed ({_hf_err}) — continuing, will fail at download if token is bad")
+
+STEPS_DONE.append(2)
+print_dashboard()
+
+# ── Step 3: NGC API key check (for NIM mode) ──────────────────────────────────
+header("Step 3 — NGC API key (NIM mode)", eta="<5s")
+# nim_local backend = local Docker container (this sprint); _cfg["nim"] = NVCF cloud catalog (NIM hosted)
+if INFERENCE_BACKEND == "nim_local":
+    if not NGC_API_KEY:
+        print("  ✗  INFERENCE_BACKEND=nim_local requires NGC_API_KEY (export NGC_API_KEY=nvapi-...)"); sys.exit(1)
+    if not NGC_API_KEY.startswith("nvapi-"):
+        warn("NGC_API_KEY does not start with 'nvapi-' — docker pull nvcr.io may fail")
+    ok(f"NGC_API_KEY set ({len(NGC_API_KEY)} chars) — nim_local Docker mode enabled")
+elif _cfg["nim"]:
+    if NGC_API_KEY:
+        if NGC_API_KEY.startswith("nvapi-"):
+            ok(f"NGC_API_KEY set ({len(NGC_API_KEY)} chars, nvapi- prefix) — NIM-{MODEL_SIZE} enabled")
+        else:
+            warn(f"NGC_API_KEY set but does not start with 'nvapi-' — NIM calls may fail")
+    else:
+        info(f"NGC_API_KEY not set — NIM-{MODEL_SIZE} will be skipped in Gradio UI")
+        info("To enable NIM: export NGC_API_KEY=nvapi-...")
+else:
+    info(f"MODEL_SIZE={MODEL_SIZE} has no NIM endpoint in catalog — NIM step skipped")
+STEPS_DONE.append(3)
+
+# ── Step 4: uv ────────────────────────────────────────────────────────────────
+header("Step 4 — uv package manager", eta="<5s if cached, ~10s first time")
+rc, _ = run_cmd(["uv", "--version"], env=ENV)
+if rc == 0:
+    _, ver = run_cmd(["uv", "--version"], env=ENV)
+    ok(f"uv already installed ({ver.strip()})")
+else:
+    run("Installing uv  (~10s)")
+    t0 = time.time()
+    rc = stream_cmd(["bash", "-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"], env=ENV)
+    if rc != 0:
+        print("  ✗  uv install failed"); sys.exit(1)
+    ok(f"uv installed in {time.time()-t0:.0f}s")
+STEPS_DONE.append(4)
+
+# ── Step 5: cosmos-reason2 repo ───────────────────────────────────────────────
+header("Step 5 — cosmos-reason2 repo", eta="<5s if cached, ~15s first time")
+if os.path.exists(f"{REASON2_DIR}/.git"):
+    ok(f"cosmos-reason2 already cloned at {REASON2_DIR}")
+else:
+    run("Cloning cosmos-reason2  (~15s)")
+    t0 = time.time()
+    rc = stream_cmd(
+        ["git", "clone", "https://github.com/nvidia-cosmos/cosmos-reason2.git", REASON2_DIR],
+        env=ENV
+    )
+    if rc != 0:
+        print("  ✗  git clone failed"); sys.exit(1)
+    ok(f"Cloned in {time.time()-t0:.0f}s")
+STEPS_DONE.append(5)
+
+# ── Step 6: Python dependencies ───────────────────────────────────────────────
+header("Step 6 — Python dependencies (uv sync)", eta="<5s if cached, ~2-3 min first time")
+venv_marker = f"{REASON2_DIR}/.venv/lib"
+if os.path.exists(venv_marker):
+    ok("virtualenv already present — skipping uv sync")
+else:
+    _extras = os.environ.get("COSMOS_EXTRAS", "cu128")
+    run(f"Running uv sync --extra {_extras}  (~2-3 min)")
+    t0 = time.time()
+    rc, out = run_cmd(["uv", "sync", "--extra", _extras], cwd=REASON2_DIR, env=ENV, timeout=600)
+    if rc != 0:
+        run(f"{_extras} failed, trying uv sync without extras")
+        rc, out = run_cmd(["uv", "sync"], cwd=REASON2_DIR, env=ENV, timeout=600)
+    if rc != 0:
+        print("  ✗  uv sync failed:", out[-500:]); sys.exit(1)
+    ok(f"Dependencies installed in {time.time()-t0:.0f}s")
+
+# ── Step 6b: vLLM version pin for CUDA 12.8 ──────────────────────────────────
+# vLLM version matrix for cu128 environments (Hyperstack H100, driver 570.x = CUDA 12.8):
+#   vLLM 0.11.0 → requires torch 2.8.0  (ABI mismatch: cu128 uv sync installs torch 2.9.0)
+#   vLLM 0.14.0 → requires torch 2.9.1+cu128 ✅ compatible with CUDA 12.8 driver
+#   vLLM 0.20.1 → requires torch 2.11.0+cu130 (needs CUDA 13.0 driver = driver 575.x+)
+# Rule: driver_major < 575 → pin vLLM 0.14.0. Driver ≥ 575 → allow latest vLLM.
+try:
+    import subprocess as _sp_cuda
+    _smi = _sp_cuda.check_output(
+        ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+        timeout=10, text=True
+    ).strip().split(".")[0:2]
+    _driver_major = int(_smi[0])
+    if _driver_major < 575:  # < CUDA 13.0 threshold → cu128 pin required
+        header("Step 6b — vLLM pin for CUDA 12.8", eta="~30-60s")
+        rc_vllm, out_vllm = run_cmd(
+            ["uv", "pip", "install", "vllm==0.14.0"],
+            cwd=REASON2_DIR, env=ENV, timeout=180
+        )
+        if rc_vllm == 0:
+            ok("vLLM pinned to 0.14.0 (torch 2.9.1+cu128) — compatible with CUDA 12.8 driver")
+        else:
+            warn(f"vLLM 0.14.0 pin failed — check pip output: {out_vllm[-300:]}")
+            warn("vLLM ABI mismatch may cause ImportError at startup")
+except Exception:
+    pass  # CUDA check is best-effort; if nvidia-smi fails, proceed as-is
+
+# ── Step 6c: ninja build system (required by flashinfer / torch compile) ─────
+try:
+    import subprocess as _sp_ninja
+    _sp_ninja.check_output(["ninja", "--version"], timeout=5, stderr=_sp_ninja.DEVNULL)
+except Exception:
+    header("Step 6c — ninja build system", eta="<5s")
+    try:
+        import subprocess as _sp_ninja2
+        _sp_ninja2.run(["apt-get", "install", "-y", "ninja-build"],
+                       timeout=60, check=True, capture_output=True)
+        ok("ninja-build installed")
+    except Exception as _e_ninja:
+        warn(f"ninja install failed ({_e_ninja}) — vLLM may fail with flashinfer JIT")
+
+STEPS_DONE.append(6)
+print_dashboard()
+
+# ── Step 7: PyAV ──────────────────────────────────────────────────────────────
+header("Step 7 — PyAV video backend", eta="<5s if cached, ~10s first time")
+rc, av_check = run_cmd(
+    ["uv", "run", "python", "-c", "import av; print(av.__version__)"],
+    cwd=REASON2_DIR, env=ENV
+)
+if rc == 0 and "16.1.0" in av_check:
+    ok(f"PyAV already installed ({av_check.strip()})")
+else:
+    run("Installing av==16.1.0  (~10s)")
+    t0 = time.time()
+    rc, out = run_cmd(["uv", "pip", "install", "av==16.1.0"], cwd=REASON2_DIR, env=ENV)
+    if rc != 0:
+        print("  ✗  av install failed:", out); sys.exit(1)
+    ok(f"PyAV installed in {time.time()-t0:.0f}s")
+
+# ── Step 8: Gradio + requests ─────────────────────────────────────────────────
+header("Step 8 — Gradio + requests", eta="<5s if cached, ~30s first time")
+rc, gr_check = run_cmd(
+    ["uv", "run", "python", "-c", "import gradio; print(gradio.__version__)"],
+    cwd=REASON2_DIR, env=ENV
+)
+if rc == 0:
+    ok(f"Gradio already installed ({gr_check.strip()})")
+else:
+    run("Installing gradio  (~30s)")
+    t0 = time.time()
+    rc, out = run_cmd(["uv", "pip", "install", "gradio"], cwd=REASON2_DIR, env=ENV, timeout=120)
+    if rc != 0:
+        print("  ✗  gradio install failed:", out); sys.exit(1)
+    ok(f"Gradio installed in {time.time()-t0:.0f}s")
+
+rc, rq_check = run_cmd(
+    ["uv", "run", "python", "-c", "import requests; print(requests.__version__)"],
+    cwd=REASON2_DIR, env=ENV
+)
+if rc == 0:
+    ok(f"requests already installed ({rq_check.strip()})")
+else:
+    run("Installing requests  (~5s)")
+    rc, out = run_cmd(["uv", "pip", "install", "requests"], cwd=REASON2_DIR, env=ENV)
+    if rc != 0:
+        warn(f"requests install failed — NIM API mode unavailable: {out}")
+    else:
+        ok("requests installed")
+
+STEPS_DONE.append(7)
+
+# ── Step 7b: Gradio frpc binary (required for public share link) ─────────────
+# frpc_linux_amd64_v0.3 is required for Gradio's SHARE=true tunnel.
+# On fresh instances, ~/.cache/huggingface/gradio/ may be missing or root-owned.
+# We pre-download to $HF_HOME/gradio/frpc/ so Gradio finds it without auth.
+_frpc_dir  = os.path.join(HF_HOME_DIR, "gradio", "frpc")
+_frpc_path = os.path.join(_frpc_dir, "frpc_linux_amd64_v0.3")
+if not os.path.exists(_frpc_path):
+    header("Step 7b — Gradio frpc binary (share link tunnel)", eta="~5s")
+    os.makedirs(_frpc_dir, exist_ok=True)
+    _frpc_url = "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_amd64"
+    try:
+        urllib.request.urlretrieve(_frpc_url, _frpc_path)
+        os.chmod(_frpc_path, 0o755)
+        ok(f"frpc binary downloaded to {_frpc_path}")
+    except Exception as _frpc_err:
+        warn(f"frpc download failed ({_frpc_err}) — public Gradio share link may not work")
+else:
+    ok(f"frpc binary already present ({_frpc_path})")
+
+# ── Step 9: Model weights ──────────────────────────────────────────────────────
+
+def download_model(model_name, model_dir, size_hint, dl_env):
+    """Download one HF model. Returns True on success."""
+    model_marker  = os.path.join(model_dir, "model.safetensors")
+    config_marker = os.path.join(model_dir, "config.json")
+    if os.path.exists(model_marker) or os.path.exists(config_marker):
+        size_mb = 0
+        if os.path.exists(model_marker):
+            size_mb = os.path.getsize(model_marker) // (1024 * 1024)
+        info_str = f"{size_mb:,} MB" if size_mb else "already present"
+        ok(f"Weights already downloaded ({model_name}, {info_str})")
+        return True
+
+    run(f"Downloading {model_name}  ({size_hint}, may take several minutes)")
+    info("Progress below — download continues even if it looks stalled:")
+    t0 = time.time()
+    MAX_RETRIES = 5
+    rc = 1
+    for attempt in range(1, MAX_RETRIES + 1):
+        rc = stream_cmd(
+            ["uv", "run", "hf", "download", model_name,
+             "--local-dir", model_dir],
+            cwd=REASON2_DIR, env=dl_env, prefix="HF │ "
+        )
+        if rc == 0:
+            break
+        if attempt < MAX_RETRIES:
+            print(f"  ✗  Attempt {attempt} failed. Retry {attempt}/{MAX_RETRIES} after 30s", flush=True)
+            for _t in range(30):
+                time.sleep(1)
+                if _t % 10 == 9:
+                    _elapsed = int(time.time() - SETUP_START)
+                    print(f"  ⟳  Retry in {30-_t-1}s | Elapsed: {_elapsed//60}m {_elapsed%60}s{credits_spent()}", flush=True)
+        else:
+            print(f"  ✗  All {MAX_RETRIES} attempts failed for {model_name}.")
+            return False
+    elapsed = time.time() - t0
+    ok(f"Downloaded {model_name} in {elapsed/60:.1f} min")
+    return True
+
+
+dl_env = {**ENV, "HF_TOKEN": HF_TOKEN}
+
+if INFERENCE_BACKEND == "nim_local":
+    info("nim_local backend — skipping HF weights download (NIM container ships the model)")
+else:
+    for i, (var_label, var_dirname, var_hf_id, var_size) in enumerate(_cfg["variants"]):
+        step_label = f"Step 9{'abcde'[i]} — {var_label} weights ({var_dirname})"
+        header(step_label, eta=f"<5s if cached, longer first time ({var_size})")
+        var_dir = os.path.join(MODELS_BASE, var_dirname)
+        ok_ = download_model(var_hf_id, var_dir, var_size, dl_env)
+        if not ok_ and i == 0:
+            sys.exit(1)  # primary variant is required
+        elif not ok_:
+            warn(f"{var_label} download failed — will fall back to HF on first Gradio use")
+
+STEPS_DONE.append(9)
+print_dashboard()
+
+# ── Step 9-NIM: Launch NIM container (nim_local backend only) ────────────────
+if INFERENCE_BACKEND == "nim_local":
+    header("Step 9-NIM — Launch NIM Docker container", eta="~30s if image cached, 10-30 min first pull")
+    # Resolve NIM image short id from MODEL_ID. Examples:
+    #   nvidia/Cosmos-Reason2-8B  -> cosmos-reason2-8b
+    #   nvidia/Cosmos-Reason2-2B  -> cosmos-reason2-2b
+    #   nvidia/Cosmos-Reason2-32B -> cosmos-reason2-32b
+    _nim_short = (MODEL_ID.split("/")[-1] if "/" in MODEL_ID else MODEL_ID).lower()
+    _nim_short = os.environ.get("NIM_MODEL_SHORT", _nim_short)
+    _nim_image = os.environ.get("NIM_IMAGE", f"nvcr.io/nim/nvidia/{_nim_short}:latest")
+    _nim_port = int(os.environ.get("NIM_PORT", "8000"))
+    _nim_launch = "/tmp/nim_launch.sh"
+    if not os.path.exists(_nim_launch):
+        print(f"  ✗  {_nim_launch} not found — deploy nim_launch.sh first"); sys.exit(1)
+    info(f"Image: {_nim_image} | Port: {_nim_port} | Container: cosmos-nim")
+    _nim_env = {
+        **ENV,
+        "NGC_API_KEY":     NGC_API_KEY,
+        "MODEL":           _nim_short,
+        "IMAGE":           _nim_image,
+        "PORT":            str(_nim_port),
+        "CONTAINER_NAME":  "cosmos-nim",
+        "LOCAL_NIM_CACHE": os.environ.get("LOCAL_NIM_CACHE", os.path.expanduser("~/.cache/nim")),
+    }
+    rc = stream_cmd(["bash", _nim_launch], env=_nim_env, prefix="NIM │ ")
+    if rc != 0:
+        print(f"  ✗  NIM launch failed (rc={rc}). Logs: /tmp/nim_launch.log + docker logs cosmos-nim"); sys.exit(1)
+    # Point Gradio at the NIM container by overriding VLLM_BASE_URL.
+    os.environ["VLLM_BASE_URL"] = f"http://localhost:{_nim_port}/v1"
+    ok(f"NIM container live at http://localhost:{_nim_port}/v1")
+
+# ── Step 9b: vLLM server auto-start (BUG-VLLM-AUTOSTART) ─────────────────────
+# In vLLM mode Gradio connects to localhost:8000. If vLLM isn't running, the first
+# inference request fails with "Connection refused". Start it here, before Gradio.
+VLLM_LOG_FILE = "/tmp/vllm_server.log"
+if INFERENCE_BACKEND == "vllm":
+    _vllm_ready = False
+    try:
+        urllib.request.urlopen("http://localhost:8000/v1/models", timeout=3)
+        _vllm_ready = True
+        ok("vLLM already running on :8000 — reusing")
+    except Exception:
+        pass
+
+    if not _vllm_ready:
+        header("Step 9b — Start vLLM server", eta="~60-120s for model load")
+        _vllm_flags  = _cfg.get("vllm_extra_flags", ["--gpu-memory-utilization", "0.85"])
+        _vllm_maxlen = _cfg.get("vllm_max_model_len", VLLM_MAX_MODEL_LEN)
+        _vllm_cmd = [
+            f"{REASON2_DIR}/.venv/bin/vllm", "serve", MODEL_DIR,
+            "--served-model-name", MODEL_NAME,
+            "--port", "8000",
+            "--dtype", "auto",
+            "--trust-remote-code",
+            "--max-model-len", str(_vllm_maxlen),
+        ] + _vllm_flags
+
+        _vllm_proc_env = {**ENV, **_cfg.get("vllm_env", {})}
+        run(f"Launching vLLM server for {MODEL_SIZE} (log: {VLLM_LOG_FILE})")
+        with open(VLLM_LOG_FILE, "w") as _vf:
+            subprocess.Popen(_vllm_cmd, cwd=REASON2_DIR, env=_vllm_proc_env,
+                             stdout=_vf, stderr=subprocess.STDOUT)
+
+        # 32B models need ~5 min for torch.compile + CUDA graph warmup.
+        _LARGE_MODEL_SIZES = {"32B", "C3-32B", "C3-super", "QW3-32B"}
+        VLLM_TIMEOUT = 420 if MODEL_SIZE in _LARGE_MODEL_SIZES else 180
+        t_vllm = time.time()
+        while time.time() - t_vllm < VLLM_TIMEOUT:
+            try:
+                urllib.request.urlopen("http://localhost:8000/v1/models", timeout=3)
+                _vllm_ready = True
+                break
+            except Exception:
+                time.sleep(5)
+
+        if not _vllm_ready:
+            print(f"  ✗  vLLM server did not start within {VLLM_TIMEOUT}s. Check {VLLM_LOG_FILE}")
+            sys.exit(1)
+        ok(f"vLLM ready in {int(time.time() - t_vllm)}s")
+
+# ── Step 10: Launch Gradio ────────────────────────────────────────────────────
+header("Step 10 — Launch Gradio web demo", eta="~5-10s for model load")
+
+if not os.path.exists(GRADIO_APP):
+    print(f"  ✗  {GRADIO_APP} not found — deploy gradio_cr2_byo.py first"); sys.exit(1)
+
+if os.path.exists(URL_FILE):
+    os.remove(URL_FILE)
+
+launch_env = {
+    **ENV,
+    "MODEL_SIZE":         MODEL_SIZE,
+    "MODEL_DIR":          MODEL_DIR,
+    "MODEL_NAME":         MODEL_NAME,
+    "GRADIO_PORT":        str(GRADIO_PORT),
+    "GRADIO_SHARE":       "true",
+    "PYTHONUNBUFFERED":   "1",
+    "HF_TOKEN":           HF_TOKEN,
+    "NGC_API_KEY":        NGC_API_KEY,
+    "LOW_VRAM":           "true" if LOW_VRAM else "false",
+    "GRADIO_FPS":         str(gradio_fps),
+    "GRADIO_MAX_PIXELS":  str(max_pixels),
+    "GRADIO_PREFILL_TPS": str(prefill_tps),
+    "INFERENCE_BACKEND":  INFERENCE_BACKEND,
+    "VLLM_BASE_URL":      os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1"),
+    "VLLM_API_KEY":       os.environ.get("VLLM_API_KEY", "EMPTY"),
+    "COSMOS_EXTRAS":      os.environ.get("COSMOS_EXTRAS", "cu128"),
+    "FLASHINFER_DISABLE_VERSION_CHECK": "1",
+    # MAXLEN-001: always pass explicitly — never rely on vLLM default (8192 breaks video queries)
+    "VLLM_MAX_MODEL_LEN": str(_cfg.get("vllm_max_model_len", VLLM_MAX_MODEL_LEN)),
+    # PRELOAD-001: skip HF preload when using vLLM backend
+    "SKIP_HF_PRELOAD":    "1" if INFERENCE_BACKEND == "vllm" else "0",
+}
+
+run(f"Starting Cosmos Reason2 {MODEL_SIZE} demo on port {GRADIO_PORT}")
+
+proc = subprocess.Popen(
+    ["uv", "run", "python", "-u", "/tmp/gradio_cr2_byo.py"],
+    cwd=REASON2_DIR,
+    env=launch_env,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    bufsize=1,
+)
+
+# BUG-SHARE-TIMEOUT: When gradio.live is firewalled (locked-down Brev orgs,
+# air-gapped hosts), the share link never appears and the loop used to terminate
+# the child Gradio process after 300s — destroying a working local-only demo.
+# Fix: detect explicit "Could not create share link" or "Running on local URL"
+# signals and fall back to a host-reachable local URL instead of killing.
+url = None
+local_url = None
+share_failed = False
+url_pattern        = re.compile(r'(https?://[^\s"\']+gradio\.live[^\s"\']*)')
+local_url_pattern  = re.compile(r'Running on local URL:\s+(http://[^\s]+)')
+URL_CAPTURE_TIMEOUT = 300
+t_launch = time.time()
+with open(LOG_FILE, "w") as log:
+    for line in proc.stdout:
+        log.write(line)
+        log.flush()
+        stripped = line.rstrip()
+        if stripped:
+            print(f"     {DIM}{stripped}{RESET}", flush=True)
+        m = url_pattern.search(stripped)
+        if m:
+            url = m.group(1).rstrip(".")
+            break
+        ml = local_url_pattern.search(stripped)
+        if ml and not local_url:
+            local_url = ml.group(1).rstrip("/")
+        if "Could not create share link" in stripped:
+            share_failed = True
+            if local_url:
+                break
+        if time.time() - t_launch > URL_CAPTURE_TIMEOUT:
+            print(f"  ⚠  No gradio.live URL after {URL_CAPTURE_TIMEOUT}s — falling back to local URL.")
+            break
+
+def _detect_host_ip():
+    env_ip = os.environ.get("BYO_VIDEO_LOCAL_HOST")
+    if env_ip:
+        return env_ip
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(2)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        if ip and not ip.startswith("127."):
+            return ip
+    except Exception:
+        pass
+    try:
+        out = subprocess.run(["hostname", "-I"], capture_output=True, text=True, timeout=2)
+        for tok in out.stdout.split():
+            if "." in tok and not tok.startswith("127."):
+                return tok
+    except Exception:
+        pass
+    try:
+        ip = socket.gethostbyname(socket.gethostname())
+        if not ip.startswith("127."):
+            return ip
+    except Exception:
+        pass
+    return None
+
+if not url:
+    if not local_url:
+        print("  ✗  Gradio printed no URL (neither share nor local). Check /tmp/gradio_demo.log")
+        proc.terminate()
+        sys.exit(1)
+    host_ip = _detect_host_ip()
+    if host_ip:
+        url = local_url.replace("0.0.0.0", host_ip).replace("127.0.0.1", host_ip)
+    else:
+        url = local_url
+    reason = "share link unavailable (host firewalled)" if share_failed else "share link timed out"
+    print(f"  ⚠  {reason}. Using local URL: {url}")
+    print(f"     {DIM}If your machine can't reach {url} directly, run on your client:{RESET}")
+    print(f"     {DIM}  ssh -L {GRADIO_PORT}:localhost:{GRADIO_PORT} <user@host>{RESET}")
+    print(f"     {DIM}then open http://localhost:{GRADIO_PORT}/ in your browser.{RESET}")
+
+# BUG-LIVENESS: probe Gradio /info before declaring live.
+# Writing URL_FILE before confirming the process survived causes stale live declarations.
+# We poll the local port (not the public URL) because frpc tunnel may lag by a few seconds.
+_live_flag = "/tmp/gradio_live.flag"
+_probe_ok = False
+for _probe_attempt in range(10):
+    try:
+        urllib.request.urlopen(f"http://localhost:{GRADIO_PORT}/", timeout=3)
+        _probe_ok = True
+        break
+    except Exception:
+        time.sleep(2)
+
+if not _probe_ok:
+    print("  ✗  Gradio process launched but / probe failed after 20s — process may have crashed.")
+    print(f"     Check {LOG_FILE} for errors.")
+    sys.exit(1)
+
+with open(URL_FILE, "w") as f:
+    f.write(url + "\n")
+
+with open(_live_flag, "w") as f:
+    f.write(url + "\n")
+
+ok("Demo server up, public tunnel established")
+STEPS_DONE.append(9)
+print_dashboard()
+
+# ── Final: print clickable hyperlink ────────────────────────────────────────
+print(flush=True)
+print(f"{BOLD}{'─'*62}{RESET}", flush=True)
+print(f"{BOLD}  Cosmos Reason2 {MODEL_SIZE} Demo — Ready{RESET}", flush=True)
+print(f"{'─'*62}", flush=True)
+print(f"  {BOLD}URL:{RESET}  {hyperlink(url)}", flush=True)
+print(f"  {DIM}Upload any MP4 → select checkpoint → Run Inference{RESET}", flush=True)
+print(f"  {DIM}Run All Variants: {_variant_labels}{RESET}", flush=True)
+print(f"  {DIM}Results: /tmp/byo_video_reason2_results.json{RESET}", flush=True)
+print(f"  {DIM}Benchmark: /tmp/byo_video_benchmark.json{RESET}", flush=True)
+print(f"  {DIM}Link valid for 72h. Kill instance when done.{RESET}", flush=True)
+if _cfg["nim"] and not NGC_API_KEY:
+    print(f"  {YELLOW}⚠  NIM-{MODEL_SIZE} mode requires NGC_API_KEY=nvapi-...{RESET}", flush=True)
+print(f"{'─'*62}", flush=True)
+print(flush=True)
+
+# BUG-STDOUT-PIPE: Keep stdout pipe alive so Gradio's print(flush=True) calls
+# don't get BrokenPipeError. Closing the read end here caused every inference
+# request to fail at Step 1 — the first yield fired, then the next print()
+# raised BrokenPipeError and the generator died. Drain thread keeps it open.
+import threading as _thr
+
+def _drain_gradio_stdout(fh, path):
+    try:
+        with open(path, "a") as f:
+            for line in fh:
+                f.write(line)
+                f.flush()
+    except Exception:
+        pass
+
+_thr.Thread(target=_drain_gradio_stdout, args=(proc.stdout, LOG_FILE), daemon=True).start()
+
+# Stay alive while Gradio runs — without this, the subprocess gets SIGHUP when
+# the screen session's controlling process exits.
+try:
+    proc.wait()
+except KeyboardInterrupt:
+    proc.terminate()
+    proc.wait()

--- a/.claude/scripts/cosmos_deploy_monitor.py
+++ b/.claude/scripts/cosmos_deploy_monitor.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""
+cosmos_deploy_monitor.py — Local deployment monitoring agent for /byo-video pipeline.
+
+Manages the pipeline on an existing Brev instance: BUILDING wait → script deploy →
+setup launch → Gradio live detection. Outputs a formatted checklist each poll cycle
+so every Monitor notification shows full pipeline state.
+
+If the instance goes UNHEALTHY, waits 3 min, then rotates to the next provider
+in the priority list. When all providers are exhausted, exits 2 so the main agent
+can AskUserQuestion.
+
+Exit codes:
+  0  DONE     — Gradio live. URL in /tmp/cosmos_deploy_state.json.
+  1  ERROR    — Unrecoverable. Message in state file.
+  2  INPUT    — Needs user decision. Options in state file.
+
+Usage:
+  python3 cosmos_deploy_monitor.py \\
+    --instance c3r-nano \\
+    --model-id nvidia/Cosmos3-Nano-Reasoner \\
+    --model-size C3-8B \\
+    --backend vllm \\
+    --rate 3.70 \\
+    --provider gpu-h100-sxm.1gpu-16vcpu-200gb \\
+    --provider-label "H100 SXM"
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import time
+
+STATE_FILE  = "/tmp/cosmos_deploy_state.json"
+LIVE_FLAG   = "/tmp/gradio_live.flag"
+SETUP_LOG   = "/tmp/byo_video_setup.log"
+SCRIPTS_DIR = os.path.expanduser("~/.claude/scripts")
+
+PROVIDER_PRIORITY = [
+    {"type": "gpu-h100-sxm.1gpu-16vcpu-200gb", "label": "H100 SXM",       "rate": 3.70, "gpu": "H100"},
+    {"type": "hyperstack_A100",                 "label": "A100-80GB",       "rate": 2.20, "gpu": "A100"},
+    {"type": "hyperstack_H100",                 "label": "H100 Hyperstack", "rate": 3.70, "gpu": "H100"},
+    {"type": "scaleway_A40",                    "label": "A40",             "rate": 1.10, "gpu": "A40"},
+]
+
+EXPECTED_SECS = {
+    "vllm": {
+        "2B": 900, "8B": 1200, "32B": 2400,
+        "C3-2B": 900, "C3-8B": 1200, "C3-32B": 2400,
+        "NEM-12B": 1200,
+        "QW3-2B": 720, "QW3-8B": 900, "QW3-32B": 1800,
+    },
+    "hf": {"2B": 600, "8B": 720},
+}
+
+# Display labels for the 10 steps (script uses 1-7 + 9 + 9b + 10)
+STEP_LABELS = {
+    1: "GPU detect + VRAM tier",
+    2: "HF auth + token validate",
+    3: "NGC API key",
+    4: "uv package manager",
+    5: "cosmos-reason2 repo",
+    6: "uv sync + CUDA libs",
+    7: "PyAV + Gradio + requests",
+    9: "Model weights download",
+    10: "Gradio launch",
+}
+
+
+# Models that don't require an HF token (fully public)
+HF_PUBLIC_MODELS = {"QW3-2B", "QW3-8B", "QW3-32B"}
+
+
+def is_public_model(model_size):
+    return model_size in HF_PUBLIC_MODELS
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run_local(args_list, timeout=30):
+    result = subprocess.run(args_list, capture_output=True, text=True, timeout=timeout)
+    return result.stdout.strip(), result.returncode
+
+
+def brev_ls(instance):
+    """Return (status, build, shell) or (None, None, None) if not found."""
+    out, _ = _run_local(["brev", "ls"], timeout=20)
+    for line in out.splitlines():
+        if instance in line:
+            parts = line.split()
+            if len(parts) >= 4:
+                return parts[1], parts[2], parts[3]
+    return None, None, None
+
+
+def brev_exec(instance, remote_cmd, timeout=60):
+    """Run a command on a Brev instance. Returns (stdout, returncode)."""
+    result = subprocess.run(
+        ["brev", "exec", instance, remote_cmd],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def brev_create(instance, provider):
+    gpu_flag = provider["gpu"]
+    out, rc = _run_local(
+        ["brev", "create", instance, "--gpu-name", gpu_flag, "--type", provider["type"]],
+        timeout=60,
+    )
+    return out, rc
+
+
+def brev_delete(instance):
+    _run_local(["brev", "delete", instance], timeout=30)
+
+
+def deploy_hf_token(instance, state, done_steps, current_step):
+    """Read local HF token, deploy to instance, validate via whoami API.
+    Exits 2 if token is missing or invalid; exits 1 on hard deploy failure."""
+    local_path = os.path.expanduser("~/.cache/huggingface/token")
+
+    if not os.path.exists(local_path):
+        state["exit_code"] = 2
+        state["message"] = (
+            "HF token not found at ~/.cache/huggingface/token.\n"
+            "Copy your token from huggingface.co/settings/tokens, then run:\n"
+            "  pbpaste > ~/.cache/huggingface/token\n"
+            "Re-run the monitor to continue."
+        )
+        state["options"] = [
+            "Get token at huggingface.co/settings/tokens → copy → pbpaste > ~/.cache/huggingface/token  then retry",
+            "Cancel deployment",
+        ]
+        write_state(state)
+        print_checklist(state, done_steps, current_step, "")
+        sys.exit(2)
+
+    with open(local_path, "r") as f:
+        token = f.read().strip()
+
+    if not token:
+        state["exit_code"] = 2
+        state["message"] = "~/.cache/huggingface/token is empty — paste a valid token first."
+        state["options"] = ["pbpaste > ~/.cache/huggingface/token  then retry", "Cancel deployment"]
+        write_state(state)
+        print_checklist(state, done_steps, current_step, "")
+        sys.exit(2)
+
+    state["last_action"] = "Deploying HF token to instance..."
+    print_checklist(state, done_steps, current_step, "")
+    write_state(state)
+
+    # Ensure remote cache dir exists
+    brev_exec(instance, "mkdir -p ~/.cache/huggingface", timeout=15)
+
+    # Deploy token via base64 (avoids shell quoting issues with token characters)
+    b64_token = base64.b64encode(token.encode()).decode()
+    write_cmd = (
+        "python3 -c \""
+        "import base64,os; "
+        "p=os.path.expanduser('~/.cache/huggingface/token'); "
+        f"open(p,'w').write(base64.b64decode('{b64_token}').decode()); "
+        "os.chmod(p,0o600)"
+        "\""
+    )
+    _, rc = brev_exec(instance, write_cmd, timeout=30)
+    if rc != 0:
+        state["last_action"] = "⚠️ Token deploy failed — retrying..."
+        print_checklist(state, done_steps, current_step, "")
+        _, rc = brev_exec(instance, write_cmd, timeout=30)
+        if rc != 0:
+            state["phase"]     = "ERROR"
+            state["exit_code"] = 1
+            state["message"]   = "Failed to deploy HF token to instance after 2 attempts"
+            write_state(state)
+            sys.exit(1)
+
+    # Validate token via HF whoami API
+    state["last_action"] = "Validating HF token with HuggingFace..."
+    print_checklist(state, done_steps, current_step, "")
+    write_state(state)
+
+    validate_cmd = (
+        'TOKEN=$(cat ~/.cache/huggingface/token) && '
+        'curl -sf -H "Authorization: Bearer $TOKEN" https://huggingface.co/api/whoami-v2'
+    )
+    whoami_out, rc = brev_exec(instance, validate_cmd, timeout=30)
+
+    if rc == 0 and whoami_out.strip().startswith("{"):
+        try:
+            info   = json.loads(whoami_out)
+            user   = info.get("name", "unknown")
+            orgs   = [o["name"] for o in info.get("orgs", [])]
+            org_s  = ", ".join(orgs[:3]) or "none"
+            state["last_action"] = f"✓ HF token valid (user: {user}, orgs: [{org_s}])"
+        except (json.JSONDecodeError, KeyError):
+            state["last_action"] = "✓ HF token validated"
+    else:
+        state["exit_code"] = 2
+        state["message"] = (
+            "HF token validation failed — token may be expired or lack nvidia org access.\n"
+            "Get a fresh token at huggingface.co/settings/tokens, then:\n"
+            "  pbpaste > ~/.cache/huggingface/token"
+        )
+        state["options"] = [
+            "Refresh token: huggingface.co/settings/tokens → copy → pbpaste > ~/.cache/huggingface/token  then retry",
+            "Cancel deployment",
+        ]
+        write_state(state)
+        print_checklist(state, done_steps, current_step, "")
+        sys.exit(2)
+
+    print_checklist(state, done_steps, current_step, "")
+    write_state(state)
+
+
+def write_state(state):
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def elapsed_fmt(start):
+    s = int(time.time() - start)
+    return f"{s // 60}m {s % 60:02d}s"
+
+
+def eta_fmt(start, model_size, backend):
+    elapsed = int(time.time() - start)
+    total   = EXPECTED_SECS.get(backend, {}).get(model_size, 1200)
+    remain  = max(0, total - elapsed)
+    if remain == 0:
+        return "any moment"
+    return f"~{remain // 60}m"
+
+
+def parse_setup_log(log_text, prev_done: set, prev_current, step_start_ts: dict):
+    """Parse setup log. Updates step_start_ts in-place for timing.
+    Returns (done_steps, current_step, has_error, last_line)."""
+    done    = set()
+    current = None
+    has_err = False
+    lines   = [l for l in log_text.splitlines() if l.strip()]
+    now     = time.time()
+
+    for line in lines:
+        if "[✓] Step" in line:
+            try:
+                raw = line.split("Step")[1].split(":")[0].strip()
+                num = int(raw.rstrip("abcdefghij"))
+                done.add(num)
+                # Record completion time if not already done
+                if num not in prev_done:
+                    if str(num) not in step_start_ts:
+                        step_start_ts[str(num)] = now
+                    step_start_ts[f"{num}_done"] = now
+            except (ValueError, IndexError):
+                pass
+        elif "[→] Step" in line:
+            try:
+                raw = line.split("Step")[1].split(":")[0].strip()
+                current = int(raw.rstrip("abcdefghij"))
+                # Record start time for this step on first sight
+                if str(current) not in step_start_ts:
+                    step_start_ts[str(current)] = now
+            except (ValueError, IndexError):
+                pass
+        if ("  ✗  " in line or "exit status 1" in line
+                or "Traceback (most recent call last)" in line
+                or any(exc in line for exc in (
+                    "NameError:", "TypeError:", "AttributeError:", "ImportError:",
+                    "RuntimeError:", "ModuleNotFoundError:", "FileNotFoundError:",
+                    "KeyError:", "ValueError:", "OSError:",
+                ))):
+            has_err = True
+
+    # Step became current this cycle but wasn't tracked
+    if current and str(current) not in step_start_ts:
+        step_start_ts[str(current)] = now
+
+    last = lines[-1][:90] if lines else ""
+    return done, current, has_err, last
+
+
+def print_checklist(state, done_steps, current_step, last_log_line):
+    """Print the full checklist. Lines within 200ms batch into one Monitor notification."""
+    phase    = state["phase"]
+    elapsed  = elapsed_fmt(state["start_ts"])
+    eta      = eta_fmt(state["start_ts"], state["model_size"], state["backend"])
+    instance = state["instance"]
+    label    = state.get("provider_label", "?")
+    rate     = state.get("rate", 0)
+    model    = state.get("model_id", "?")
+    backend  = state.get("backend", "?")
+    msize    = state.get("model_size", "?")
+    action   = state.get("last_action", "")
+
+    PHASE_ORDER = ["BUILDING", "DEPLOY_SCRIPTS", "SETUP", "GRADIO_LIVE", "DONE"]
+
+    def mark(target_phase):
+        ci = PHASE_ORDER.index(phase)       if phase       in PHASE_ORDER else 0
+        ti = PHASE_ORDER.index(target_phase) if target_phase in PHASE_ORDER else 99
+        if ci > ti:  return "✓"
+        if ci == ti: return "→"
+        return " "
+
+    # Phase-level elapsed (BUILDING + DEPLOY_SCRIPTS)
+    build_elapsed  = ""
+    deploy_elapsed = ""
+    if state.get("phase_start_ts"):
+        ps = int(time.time() - state["phase_start_ts"])
+        ph_str = f"{ps // 60}m {ps % 60:02d}s"
+        if phase == "BUILDING":
+            build_elapsed  = f"  ({ph_str} — typical ~3-5m)"
+        elif phase == "DEPLOY_SCRIPTS":
+            deploy_elapsed = f"  ({ph_str} — ~30-120s)"
+
+    buf = [
+        f"Cosmos Deploy Monitor — {instance}  (elapsed: {elapsed} | ETA: {eta})",
+        f"  {label} · ${rate:.2f}/hr · {model} ({msize}, {backend})",
+        "──────────────────────────────────────────────────────────────",
+        f"  [{mark('BUILDING')}] Wait for SHELL READY{build_elapsed}",
+        f"  [{mark('DEPLOY_SCRIPTS')}] Deploy scripts{deploy_elapsed}",
+    ]
+
+    if phase in ("SETUP", "GRADIO_LIVE", "DONE"):
+        buf.append(f"  [✓] Setup launched")
+        all_done = phase in ("GRADIO_LIVE", "DONE")
+        step_starts = state.get("step_start_ts", {})
+        for num, label_s in STEP_LABELS.items():
+            if num in done_steps or all_done:
+                # Show how long the step took if recorded
+                s_start = step_starts.get(str(num))
+                s_done  = step_starts.get(f"{num}_done")
+                if s_start and s_done:
+                    took = int(s_done - s_start)
+                    buf.append(f"       ✓ Step {num}: {label_s}  ({took}s)")
+                else:
+                    buf.append(f"       ✓ Step {num}: {label_s}")
+            elif num == current_step:
+                s_start = step_starts.get(str(num))
+                running = f"  ({int(time.time() - s_start)}s)" if s_start else ""
+                buf.append(f"       → Step {num}: {label_s}{running}")
+            else:
+                buf.append(f"       [ ] Step {num}: {label_s}")
+    else:
+        buf.append(f"  [{mark('SETUP')}] Setup (byo_video_setup.py)")
+
+    buf.append(f"  [{mark('GRADIO_LIVE')}] Gradio live")
+    buf.append("──────────────────────────────────────────────────────────────")
+
+    if action:
+        buf.append(f"  ↳ {action}")
+    if last_log_line and phase == "SETUP":
+        buf.append(f"  log: {last_log_line}")
+
+    if state.get("gradio_url"):
+        buf.append(f"  🎉 {state['gradio_url']}")
+
+    print("\n".join(buf), flush=True)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instance",       required=True)
+    ap.add_argument("--model-id",       required=True)
+    ap.add_argument("--model-size",     default="2B")
+    ap.add_argument("--backend",        default="vllm", choices=["vllm", "hf"])
+    ap.add_argument("--rate",           type=float, default=3.70)
+    ap.add_argument("--provider",       default="gpu-h100-sxm.1gpu-16vcpu-200gb")
+    ap.add_argument("--provider-label", default="H100 SXM")
+    args = ap.parse_args()
+
+    # Find this provider's index in the priority list for rotation
+    prov_idx = next(
+        (i for i, p in enumerate(PROVIDER_PRIORITY) if p["type"] == args.provider), 0
+    )
+
+    state = {
+        "phase":          "BUILDING",
+        "phase_start_ts": time.time(),
+        "start_ts":       time.time(),
+        "instance":       args.instance,
+        "model_id":       args.model_id,
+        "model_size":     args.model_size,
+        "backend":        args.backend,
+        "rate":           args.rate,
+        "provider":       args.provider,
+        "provider_label": args.provider_label,
+        "gradio_url":     None,
+        "last_action":    "Waiting for SHELL READY...",
+        "exit_code":      None,
+        "message":        None,
+    }
+    write_state(state)
+
+    scripts_deployed = False
+    token_handled    = is_public_model(args.model_size)  # skip for public models
+    setup_launched   = False
+    unhealthy_start  = None
+    done_steps: set  = set()
+    current_step     = None
+    step_start_ts: dict = {}
+    state["step_start_ts"] = step_start_ts
+
+    # ── Poll loop ─────────────────────────────────────────────────────────────
+    while True:
+        try:
+            brev_status, brev_build, brev_shell = brev_ls(args.instance)
+        except subprocess.TimeoutExpired:
+            time.sleep(15)
+            continue
+
+        # ── UNHEALTHY / CREATE_FAILED detection ──────────────────────────────
+        build_failed = brev_build in ("UNHEALTHY", "FAILED", "CREATE_FAILED")
+
+        # CREATE_FAILED = never provisioned → rotate immediately, no recovery window
+        if brev_build == "CREATE_FAILED":
+            print(f"✗ {args.provider_label} CREATE_FAILED — rotating provider immediately", flush=True)
+            brev_delete(args.instance)
+            time.sleep(10)
+
+            next_providers = PROVIDER_PRIORITY[prov_idx + 1:]
+            if not next_providers:
+                state["phase"]     = "ERROR"
+                state["exit_code"] = 2
+                state["message"]   = (
+                    f"All {len(PROVIDER_PRIORITY)} providers failed (CREATE_FAILED) starting with "
+                    f"{args.provider_label}. Please choose an action."
+                )
+                state["options"] = ["Try again with same provider", "Cancel deployment"]
+                write_state(state)
+                print_checklist(state, done_steps, current_step, "")
+                sys.exit(2)
+
+            next_p              = next_providers[0]
+            prov_idx           += 1
+            args.provider       = next_p["type"]
+            args.provider_label = next_p["label"]
+            args.rate           = next_p["rate"]
+            state["provider"]       = next_p["type"]
+            state["provider_label"] = next_p["label"]
+            state["rate"]           = next_p["rate"]
+            state["last_action"]    = f"✗ CREATE_FAILED — trying {next_p['label']}"
+            print(f"  → trying {next_p['label']} ({next_p['type']})", flush=True)
+            _, rc = brev_create(args.instance, next_p)
+            if rc != 0:
+                state["last_action"] = f"⚠️ brev create {next_p['label']} also failed — will retry next cycle"
+            unhealthy_start  = None
+            scripts_deployed = False
+            token_handled    = is_public_model(args.model_size)
+            setup_launched   = False
+            done_steps       = set()
+            current_step     = None
+            state["phase"]   = "BUILDING"
+            write_state(state)
+            time.sleep(30)
+            continue
+
+        if build_failed:
+            if unhealthy_start is None:
+                unhealthy_start = time.time()
+                state["last_action"] = f"⚠️ UNHEALTHY — 3-min recovery window starting"
+
+            wait_remaining = 180 - int(time.time() - unhealthy_start)
+            if wait_remaining > 0:
+                state["phase"]       = "BUILDING"
+                state["last_action"] = f"⚠️ UNHEALTHY — checking again in 30s ({wait_remaining}s left in window)"
+                print_checklist(state, done_steps, current_step, "")
+                write_state(state)
+                time.sleep(30)
+                continue
+
+            # Recovery window expired — rotate provider
+            print(f"✗ {args.provider_label} UNHEALTHY (3-min window expired) — rotating provider", flush=True)
+            brev_delete(args.instance)
+            time.sleep(15)
+
+            next_providers = PROVIDER_PRIORITY[prov_idx + 1:]
+            if not next_providers:
+                state["phase"]    = "ERROR"
+                state["exit_code"] = 2
+                state["message"]  = (
+                    f"All {len(PROVIDER_PRIORITY)} providers exhausted after UNHEALTHY on "
+                    f"{args.provider_label}. Please choose an action."
+                )
+                state["options"] = ["Try again with same provider", "Cancel deployment"]
+                write_state(state)
+                print_checklist(state, done_steps, current_step, "")
+                sys.exit(2)
+
+            next_p           = next_providers[0]
+            prov_idx        += 1
+            args.provider    = next_p["type"]
+            args.provider_label = next_p["label"]
+            args.rate        = next_p["rate"]
+            state["provider"]       = next_p["type"]
+            state["provider_label"] = next_p["label"]
+            state["rate"]           = next_p["rate"]
+            state["last_action"]    = f"✗ {args.provider_label} — rotating to {next_p['label']}"
+
+            print(f"  → trying {next_p['label']} ({next_p['type']})", flush=True)
+            _, rc = brev_create(args.instance, next_p)
+            if rc != 0:
+                # Create failed — try next provider on next iteration
+                prov_idx -= 1  # will be re-incremented next UNHEALTHY cycle
+            unhealthy_start  = None
+            scripts_deployed = False
+            token_handled    = is_public_model(args.model_size)
+            setup_launched   = False
+            done_steps       = set()
+            current_step     = None
+            state["phase"]   = "BUILDING"
+            write_state(state)
+            time.sleep(30)
+            continue
+
+        else:
+            unhealthy_start = None  # reset on clean status
+
+        # ── Instance not found: provision it ─────────────────────────────────
+        if brev_status is None:
+            state["phase"]          = "BUILDING"
+            state["phase_start_ts"] = time.time()
+            state["last_action"]    = f"Instance not found — provisioning {args.provider_label}..."
+            scripts_deployed = False
+            token_handled    = is_public_model(args.model_size)
+            setup_launched   = False
+            print_checklist(state, done_steps, current_step, "")
+            current_p = next(
+                (p for p in PROVIDER_PRIORITY if p["type"] == args.provider),
+                PROVIDER_PRIORITY[prov_idx],
+            )
+            _, rc = brev_create(args.instance, current_p)
+            if rc != 0:
+                state["last_action"] = f"⚠️ brev create failed — will retry next cycle"
+            write_state(state)
+            time.sleep(30)
+            continue
+
+        # ── BUILDING: wait for SHELL READY ────────────────────────────────────
+        if brev_shell != "READY":
+            if state["phase"] != "BUILDING":
+                state["phase_start_ts"] = time.time()
+            state["phase"]       = "BUILDING"
+            state["last_action"] = f"Building... (BUILD={brev_build})"
+            print_checklist(state, done_steps, current_step, "")
+            write_state(state)
+            time.sleep(30)
+            continue
+
+        # ── SHELL READY: deploy scripts ───────────────────────────────────────
+        if not scripts_deployed:
+            if state["phase"] != "DEPLOY_SCRIPTS":
+                state["phase_start_ts"] = time.time()
+            state["phase"]       = "DEPLOY_SCRIPTS"
+            state["last_action"] = "SHELL READY — deploying scripts..."
+            print_checklist(state, done_steps, current_step, "")
+
+            script_names = ("byo_video_setup", "gradio_cr2_byo")
+            for idx, name in enumerate(script_names, 1):
+                path = os.path.join(SCRIPTS_DIR, f"{name}.py")
+                if not os.path.exists(path):
+                    state["phase"]     = "ERROR"
+                    state["exit_code"] = 1
+                    state["message"]   = f"Script not found locally: {path}"
+                    write_state(state)
+                    print(f"ERROR: {state['message']}", flush=True)
+                    sys.exit(1)
+
+                # Progress line fires an immediate Monitor notification
+                state["last_action"] = f"Uploading {name}.py ({idx}/{len(script_names)})..."
+                print_checklist(state, done_steps, current_step, "")
+                write_state(state)
+
+                t0 = time.time()
+                try:
+                    cp_result = subprocess.run(
+                        ["brev", "copy", path, f"{args.instance}:/tmp/{name}.py"],
+                        capture_output=True, text=True, timeout=120,
+                    )
+                    rc, cp_stderr = cp_result.returncode, cp_result.stderr
+                except subprocess.TimeoutExpired:
+                    rc, cp_stderr = 1, "brev copy timed out after 120s"
+                if rc != 0:
+                    time.sleep(5)
+                    try:
+                        cp_result = subprocess.run(
+                            ["brev", "copy", path, f"{args.instance}:/tmp/{name}.py"],
+                            capture_output=True, text=True, timeout=120,
+                        )
+                        rc, cp_stderr = cp_result.returncode, cp_result.stderr
+                    except subprocess.TimeoutExpired:
+                        rc, cp_stderr = 1, "brev copy timed out after 120s"
+                    if rc != 0:
+                        state["phase"]     = "ERROR"
+                        state["exit_code"] = 1
+                        state["message"]   = (
+                            f"Failed to deploy {name}.py after 2 attempts "
+                            f"(brev copy error: {cp_stderr[:200]})"
+                        )
+                        write_state(state)
+                        print(f"ERROR: {state['message']}", flush=True)
+                        sys.exit(1)
+
+                took = int(time.time() - t0)
+                state["last_action"] = f"✓ {name}.py uploaded ({took}s) — {idx}/{len(script_names)}"
+                print_checklist(state, done_steps, current_step, "")
+                write_state(state)
+
+            scripts_deployed     = True
+            state["last_action"] = "Scripts deployed ✓"
+            write_state(state)
+
+        # ── HF token: deploy and validate for gated models ───────────────────
+        if scripts_deployed and not token_handled:
+            deploy_hf_token(args.instance, state, done_steps, current_step)
+            token_handled        = True
+            state["last_action"] = "Credentials ready — launching setup..."
+            write_state(state)
+
+        # ── Launch setup in background ────────────────────────────────────────
+        if not setup_launched and token_handled:
+            state["phase"]       = "SETUP"
+            state["last_action"] = "Launching setup in background..."
+            print_checklist(state, done_steps, current_step, "")
+
+            inner = (
+                f"export INFERENCE_BACKEND={args.backend} "
+                f"MODEL_ID={args.model_id} "
+                f"BREV_RATE_PER_HOUR={args.rate} "
+                f"PATH=~/.local/bin:~/.cargo/bin:$PATH && "
+                f"python3 /tmp/byo_video_setup.py"
+            )
+            launch_cmd = f"nohup bash -c \"{inner}\" > {SETUP_LOG} 2>&1 &"
+            try:
+                brev_exec(args.instance, launch_cmd, timeout=30)
+            except subprocess.TimeoutExpired:
+                pass  # fire-and-forget; nohup process continues on the instance
+            setup_launched       = True
+            state["last_action"] = "Setup launched — watching log"
+            write_state(state)
+            time.sleep(20)
+            continue
+
+        # ── SETUP running: tail log, check live flag ──────────────────────────
+        if state["phase"] == "SETUP":
+            try:
+                log_raw, _ = brev_exec(
+                    args.instance, f"tail -60 {SETUP_LOG} 2>/dev/null", timeout=30
+                )
+            except subprocess.TimeoutExpired:
+                log_raw = ""
+            done_steps, current_step, has_err, last_line = parse_setup_log(
+                log_raw, done_steps, current_step, step_start_ts
+            )
+            state["step_start_ts"] = step_start_ts
+
+            # Check live flag
+            try:
+                flag_out, flag_rc = brev_exec(
+                    args.instance, f"cat {LIVE_FLAG} 2>/dev/null", timeout=15
+                )
+            except subprocess.TimeoutExpired:
+                flag_out, flag_rc = "", 1
+            url = flag_out.strip()
+            if flag_rc == 0 and url.startswith("http"):
+                state["gradio_url"]  = url
+                state["phase"]       = "GRADIO_LIVE"
+                state["last_action"] = f"Gradio live ✓"
+                done_steps           = set(STEP_LABELS.keys())
+                print_checklist(state, done_steps, None, "")
+                state["exit_code"]   = 0
+                write_state(state)
+                print(f"DONE: {url}", flush=True)
+                sys.exit(0)
+
+            # Check if setup process is still running (after 60s startup grace period)
+            setup_elapsed = int(time.time() - state["start_ts"])
+            if setup_elapsed > 60:
+                try:
+                    proc_out, _ = brev_exec(
+                        args.instance, "pgrep -f byo_video_setup.py", timeout=15
+                    )
+                except subprocess.TimeoutExpired:
+                    proc_out = "timeout"  # assume alive on timeout
+                if not proc_out.strip():
+                    state["phase"]     = "ERROR"
+                    state["exit_code"] = 1
+                    state["message"]   = (
+                        f"Setup process exited without Gradio going live. "
+                        f"Last log: {last_line or '(no log output)'}"
+                    )
+                    write_state(state)
+                    print_checklist(state, done_steps, current_step, last_line)
+                    print(f"ERROR: {state['message']}", flush=True)
+                    sys.exit(1)
+
+            # Check for setup failure
+            if has_err:
+                state["last_action"] = f"⚠️ Error in setup log: {last_line}"
+
+                # Check if vLLM or critical step failed
+                critical_failure = any(
+                    kw in log_raw
+                    for kw in (
+                        "sys.exit(1)", "CUDA out of memory", "No space left", "SIGKILL",
+                        "Traceback (most recent call last)",
+                        "NameError:", "TypeError:", "AttributeError:", "ImportError:",
+                        "RuntimeError:", "ModuleNotFoundError:", "FileNotFoundError:",
+                        "KeyError:", "ValueError:", "OSError:",
+                    )
+                )
+                if critical_failure:
+                    state["phase"]    = "ERROR"
+                    state["exit_code"] = 1
+                    state["message"]  = f"Setup failed: {last_line}"
+                    write_state(state)
+                    print_checklist(state, done_steps, current_step, last_line)
+                    sys.exit(1)
+            else:
+                state["last_action"] = last_line or "setup running..."
+
+            print_checklist(state, done_steps, current_step, last_line)
+            write_state(state)
+            time.sleep(30)
+            continue
+
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/gradio_cr2_byo.py
+++ b/.claude/scripts/gradio_cr2_byo.py
@@ -635,6 +635,17 @@ def _uses_file_url(model_id):
     """True for any model that uses file:// video URL to vLLM (vs base64 JPEG frames)."""
     return _is_nemotron(model_id) or _is_qwen3vl(model_id)
 
+def _is_cosmos_reason_nim(model_id):
+    """True when running a Cosmos Reason NIM container that natively decodes video
+    server-side (NIM_MEDIA_IO_KWARGS controls fps/sampling). When True, video must be
+    sent as a single video_url content item — extracting frames client-side and sending
+    them as image_url entries collapses motion into stills (the 5-image NIM cap then
+    wrecks 30 s+ clips by leaving ~6 s gaps between samples)."""
+    if INFERENCE_BACKEND != "nim_local":
+        return False
+    mid = (model_id or _SERVER_MODEL_ID or "").lower()
+    return "cosmos-reason" in mid
+
 def _expected_quant(model_id):
     """Infer expected quantization from model path/ID name."""
     mid = model_id.lower()
@@ -1080,8 +1091,15 @@ def _run_vllm_inference(video_path, prompt, system, fps, max_tokens, model_id, t
 
     # Step 3: prepare media content
     # Images: single image_url (file:// for Nemotron/Qwen, base64 for CR2/C3).
-    # Videos: Nemotron/Qwen3-VL use file:// video_url; CR2/C3 use base64 JPEG frames.
+    # Videos:
+    #   - Nemotron/Qwen3-VL → file:// video_url (vLLM server-side decode)
+    #   - Cosmos Reason NIM → base64 data: video_url (NIM server-side decode @ 4 fps + EVS)
+    #   - Cosmos OSS (HF/vLLM) → base64 JPEG frames (no native video pipeline in OSS path)
     _nem = _uses_file_url(model_id) or _uses_file_url(_SERVER_MODEL_ID or "")
+    _cosmos_nim_video = (
+        not is_image
+        and (_is_cosmos_reason_nim(model_id) or _is_cosmos_reason_nim(_SERVER_MODEL_ID or ""))
+    )
     if is_image:
         if _nem:
             content = [
@@ -1121,9 +1139,32 @@ def _run_vllm_inference(video_path, prompt, system, fps, max_tokens, model_id, t
             {"type": "text", "text": prompt},
         ]
         print(f"[vllm/nemotron] video_url: file://{_nem_path}", flush=True)
+    elif _cosmos_nim_video:
+        # Cosmos Reason NIMs natively decode video server-side at NIM_MEDIA_IO_KWARGS
+        # (e.g. fps=4 for cosmos-reason2-8b) with EVS engaged. Send as one video_url
+        # content item; sending extracted frames as image_url[] would hit the
+        # NIM_MAX_IMAGES_PER_PROMPT=5 cap and destroy motion on clips >~10 s.
+        # Use a base64 data: URL so we don't depend on container mounts or
+        # --allowed-local-media-path config (which the cosmos NIM doesn't expose).
+        try:
+            with open(video_path, "rb") as _vf:
+                _vid_b64 = base64.b64encode(_vf.read()).decode()
+        except Exception as _vid_err:
+            msg = f"[NIM ERROR] Could not read video for base64 encoding: {_vid_err}"
+            print(msg, flush=True)
+            _log_run(model_id, total_s=_elapsed(), status="video-read-error", display_label=display_label)
+            yield msg, _status_html(["ok", "ok", "wait", "wait", "wait"],
+                                    {"elapsed_s": _elapsed(), "backend": _be_label}, steps=steps), _table_html()
+            return
+        content = [
+            {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{_vid_b64}"}},
+            {"type": "text", "text": prompt},
+        ]
+        _vid_mb = len(_vid_b64) * 3 / 4 / (1024 * 1024)
+        print(f"[nim_local/cosmos] video_url: data:video/mp4;base64 ({_vid_mb:.1f} MB) — server-side decode", flush=True)
     else:
-        # NIM container hard-caps at 5 images/prompt; vLLM has no such cap.
-        _max_frames = 5 if INFERENCE_BACKEND == "nim_local" else 8
+        # OSS path (HF/vLLM-OSS) for Cosmos Reason: extract frames client-side.
+        _max_frames = 8
         print(f"[vllm] Extracting frames fps={fps} max={_max_frames}", flush=True)
         frames_b64 = _extract_frames_b64(video_path, fps=fps, max_frames=_max_frames)
         if not frames_b64:
@@ -1441,8 +1482,9 @@ def run_inference(video_path, user_prompt, system_prompt, fps, max_pixels, max_n
                            {"elapsed_s": _elapsed()}), gr.update()
 
     # NIM local Docker is served by `_run_vllm_inference` via the OpenAI-compatible
-    # client at VLLM_BASE_URL. The NIM container enforces a 5-image-per-prompt cap;
-    # frame clamping is applied below at extraction time when INFERENCE_BACKEND=nim_local.
+    # client at VLLM_BASE_URL. Cosmos Reason NIMs decode video natively (one video_url
+    # content item, base64 data URL — see _is_cosmos_reason_nim dispatch below);
+    # the legacy NIM_MAX_IMAGES_PER_PROMPT=5 cap only applies if you send images.
 
     if _is_nim(model_id):
         yield from _run_nim_inference(

--- a/.claude/scripts/gradio_cr2_byo.py
+++ b/.claude/scripts/gradio_cr2_byo.py
@@ -1,0 +1,2737 @@
+#!/usr/bin/env python3
+"""
+Cosmos Reason BYO-Video Gradio Demo — Multi-Checkpoint Edition
+Version: 2026-04-29
+Canonical source: ~/.claude/scripts/gradio_cr2_byo.py
+
+New in this version:
+  - Checkpoint selector: any HF model ID, local path, or NIM via Advanced Settings
+  - Sequential variant runner: FP8 → NVFP4 → NIM (Run All Variants button)
+  - On-demand load/unload (del + gc.collect + cuda.empty_cache between variants)
+  - Right-side status panel: Step N/5 WIP + live token metrics (replaces grey loading box)
+  - NIM mode: NVCF API via NGC_API_KEY (no local weights needed)
+"""
+import os, sys, gc, json, time, threading, warnings, base64, io, atexit, signal, subprocess as _sp_cleanup
+warnings.filterwarnings("ignore")
+
+def _kill_frpc():
+    """BUG-005: kill orphaned frpc tunnel processes when Gradio exits."""
+    try:
+        _sp_cleanup.run(["pkill", "-f", "frpc"], capture_output=True, timeout=5)
+    except Exception:
+        pass
+
+atexit.register(_kill_frpc)
+try:
+    signal.signal(signal.SIGTERM, lambda *_: (_kill_frpc(), sys.exit(0)))
+except Exception:
+    pass
+
+try:
+    import torch
+except ImportError:
+    print("[ERROR] torch not installed."); sys.exit(1)
+
+try:
+    import gradio as gr
+except ImportError:
+    print("[ERROR] gradio not installed. Run: pip install gradio"); sys.exit(1)
+
+try:
+    import qwen_vl_utils
+except ImportError:
+    print("[ERROR] qwen_vl_utils not installed (should be in cosmos-reason2 venv)."); sys.exit(1)
+
+try:
+    from transformers import (
+        Qwen3VLForConditionalGeneration,
+        AutoModelForCausalLM,
+        AutoProcessor,
+        TextIteratorStreamer,
+    )
+except ImportError as e:
+    print(f"[ERROR] transformers not installed: {e}"); sys.exit(1)
+
+try:
+    import av as _av_module
+    _AV_OK = True
+except ImportError:
+    _av_module = None
+    _AV_OK = False
+
+try:
+    import requests as _requests
+    _REQUESTS_OK = True
+except ImportError:
+    _requests = None
+    _REQUESTS_OK = False
+
+try:
+    import vllm as _vllm_module
+    _VLLM_VERSION = _vllm_module.__version__
+except ImportError:
+    _VLLM_VERSION = None
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+HOME        = os.path.expanduser("~")
+MODEL_DIR   = os.environ.get("MODEL_DIR",  f"{HOME}/cosmos-reason2/models/Cosmos-Reason2-2B")
+MODEL_NAME  = os.environ.get("MODEL_NAME", "nvidia/Cosmos-Reason2-2B")
+OUT_FILE    = os.environ.get("OUT_FILE",   "/tmp/byo_video_reason2_results.json")
+PORT        = int(os.environ.get("GRADIO_PORT", "7860"))
+SHARE       = os.environ.get("GRADIO_SHARE", "true").lower() != "false"
+LOW_VRAM    = os.environ.get("LOW_VRAM", "false").lower() == "true"
+HF_TOKEN    = os.environ.get("HF_TOKEN", "")
+NGC_API_KEY = os.environ.get("NGC_API_KEY", "")
+
+DEFAULT_FPS        = int(os.environ.get("GRADIO_FPS", "4" if LOW_VRAM else "8"))
+DEFAULT_MAX_PIXELS = int(os.environ.get("GRADIO_MAX_PIXELS",
+                         str(128*(32**2) if LOW_VRAM else 4096*(32**2))))
+DEFAULT_MAX_TOKENS = 512
+
+TARGET_INFER_S = 55.0
+TEXT_TOKENS    = 50
+_EMPIRICAL_VPF = 128
+_BASELINE_PX   = 524288
+_PIXEL_TIERS   = [131072, 262144, 524288, 1048576, 2097152]
+# IMAGE_AUTO_CAP_MAX bounds the auto-cap result for single images.
+# _EMPIRICAL_VPF was calibrated for video tokenization (temporal merging halves
+# tokens/frame); for Cosmos3 single-image inputs the actual vision token count
+# is ~3-5x higher per pixel, so the est-time math is too lenient and snaps to
+# the highest tier (2M px). Bound the image path to ≤512K, which empirically
+# yields ~30-50s prefill on RTX PRO 6000 Blackwell + HF Transformers.
+# User can disable auto-cap to override and use higher resolutions.
+IMAGE_AUTO_CAP_MAX = 524288
+
+NIM_ENDPOINT = "https://integrate.api.nvidia.com/v1/chat/completions"
+
+# vLLM server (OpenAI-compatible) — set INFERENCE_BACKEND=vllm to use
+INFERENCE_BACKEND = os.environ.get("INFERENCE_BACKEND", "hf").lower()   # hf | vllm | nim_local
+VLLM_BASE_URL     = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+VLLM_API_KEY      = os.environ.get("VLLM_API_KEY", "EMPTY")             # vLLM default
+
+# Prefill TPS for TTFT estimation.
+# HF mode: ~23 tok/s measured on RTX PRO 6000 Blackwell (empirical, local HTML report).
+# vLLM mode on H100: ~12000 tok/s (GSheet CR2-8B PBR; 374×374 · 30s clips:
+#   2K → 174ms, 4K → 341ms, 8K → 724ms → avg ~11,700 tok/s).
+_prefill_default = "12000" if INFERENCE_BACKEND == "vllm" else "23"
+PREFILL_TPS = float(os.environ.get("GRADIO_PREFILL_TPS", _prefill_default))
+
+# For vllm/nim_local: query the running server to get its actual served model name.
+# vLLM uses --served-model-name (e.g. "nvidia/Cosmos-Reason2-2B-FP8") which differs
+# from local checkpoint paths. NIM serves a fixed ID (e.g. "nvidia/cosmos-reason2-2b").
+# We must use this exact name in chat/completions requests or get 404.
+_NIM_LOCAL_MODEL_ID = None  # kept for backward compat
+_SERVER_MODEL_ID = None
+if INFERENCE_BACKEND in ("vllm", "nim_local"):
+    try:
+        import urllib.request as _urlreq, json as _json
+        with _urlreq.urlopen(f"{VLLM_BASE_URL}/models", timeout=5) as _r:
+            _srv_data = _json.loads(_r.read())
+            _SERVER_MODEL_ID = _srv_data["data"][0]["id"]
+            _NIM_LOCAL_MODEL_ID = _SERVER_MODEL_ID  # backward compat
+            print(f"[{INFERENCE_BACKEND}] Detected server model: {_SERVER_MODEL_ID}", flush=True)
+    except Exception as _e:
+        print(f"[{INFERENCE_BACKEND}] Could not detect model from {VLLM_BASE_URL}/models: {_e}", flush=True)
+
+# ── Size-driven model configs ──────────────────────────────────────────────────
+# Each variant: (ui_label, local_dirname, hf_model_id, expected_quant)
+# expected_quant: "bf16" | "fp8" | "nvfp4" — used to detect HF runtime upcasting
+MODEL_CONFIGS = {
+    "2B": {
+        "variants": [
+            ("CR2-2B FP8",   "Cosmos-Reason2-2B-FP8",   "nvidia/Cosmos-Reason2-2B-FP8",   "fp8"),
+            ("CR2-2B NVFP4", "Cosmos-Reason2-2B-NVFP4", "nvidia/Cosmos-Reason2-2B-NVFP4", "nvfp4"),
+            ("CR2-2B BF16",  "Cosmos-Reason2-2B",       "nvidia/Cosmos-Reason2-2B",       "bf16"),
+        ],
+        "nim": None,  # container available (nvcr.io/nim/nvidia/cosmos-reason2-2b:latest) but NOT on NVCF hosted API
+    },
+    "8B": {
+        "variants": [
+            ("CR2-8B FP8",   "Cosmos-Reason2-8B-FP8",   "nvidia/Cosmos-Reason2-8B-FP8",   "fp8"),
+            ("CR2-8B NVFP4", "Cosmos-Reason2-8B-NVFP4", "nvidia/Cosmos-Reason2-8B-NVFP4", "nvfp4"),
+            ("CR2-8B BF16",  "Cosmos-Reason2-8B",       "nvidia/Cosmos-Reason2-8B",       "bf16"),
+        ],
+        # extended_variants: appended to Run All Variants only (not in checkpoint dropdown).
+        # Runs against the loaded vLLM model — switch server to 32B first for true 32B benchmarks.
+        # In HF mode, requires unloading 8B first (~64GB weights); OOMs if 8B stays loaded.
+        "extended_variants": [
+            ("CR2-32B BF16", "Cosmos-Reason2-32B",    "nvidia/Cosmos-Reason2-32B",    "bf16"),
+            ("CR2-32B AV",   "Cosmos-Reason2-32B-AV", "nvidia/Cosmos-Reason2-32B-AV", "bf16"),
+        ],
+        "nim": "nvidia/cosmos-reason2-8b",
+    },
+    "32B": {
+        # 32B BF16 requires ~64GB weights; fits on 1x H100 80GB only with small KV cache.
+        # 32B BF16 and 32B-AV are separate checkpoints (AV = action-value variant).
+        # Serve via vLLM with --max-model-len 4096 to leave room for KV cache.
+        "variants": [
+            ("CR2-32B BF16", "Cosmos-Reason2-32B",    "nvidia/Cosmos-Reason2-32B",    "bf16"),
+            ("CR2-32B AV",   "Cosmos-Reason2-32B-AV", "nvidia/Cosmos-Reason2-32B-AV", "bf16"),
+        ],
+        "nim": None,  # TBD
+    },
+    # ── Cosmos3-Reasoner (C3-2B/C3-32B/C3-super gated; C3-8B = Cosmos3-Nano-Reasoner, public) ──
+    "C3-2B": {
+        "variants": [
+            ("C3R-2B BF16", "Cosmos3-Reasoner-2B", "nvidia/Cosmos3-Reasoner-2B-Private", "bf16"),
+        ],
+        "nim": None,
+    },
+    "C3-8B": {
+        "variants": [
+            ("C3R-Nano BF16", "Cosmos3-Nano-Reasoner", "nvidia/Cosmos3-Nano-Reasoner", "bf16"),
+        ],
+        "nim": None,
+    },
+    "C3-32B": {
+        "variants": [
+            ("C3R-32B BF16", "Cosmos3-Reasoner-32B", "nvidia/Cosmos3-Reasoner-32B-Private", "bf16"),
+        ],
+        "nim": None,
+        # disk_gb: 1024 (1TB minimum — Alex explicit requirement for 32B)
+        # vLLM: --tensor-parallel-size 1 --gpu-memory-utilization 0.93 on single H100 80GB
+        # Weight size unverified (25 files, est ~60-70GB BF16). Review if OOM occurs.
+    },
+    "C3-super": {
+        "variants": [
+            ("C3-Super BF16", "Cosmos3-Super-Reasoner", "nvidia/Cosmos3-Super-Reasoner", "bf16"),
+        ],
+        "nim": None,
+        # 32B model on H200 SXM 141GB (confirmed 2026-05-05 live deployment).
+        # Architecture: NemotronVLForConditionCausalLM. vLLM may raise "Unsupported architecture"
+        # if arch is not registered. Use INFERENCE_BACKEND=hf as fallback (confirmed working).
+    },
+    # ── Qwen3-VL (public — no HF_TOKEN required) ────────────────────────────────
+    # vLLM-only: uses video_url content type with file:// path (same pattern as Nemotron).
+    # Frame control via extra_body mm_processor_kwargs at inference time (not server flags).
+    # Three variants per size: Instruct (general), FP8 (quantized), Thinking (reasoning).
+    "QW3-2B": {
+        "variants": [
+            ("Qwen3-VL-2B Instruct", "Qwen3-VL-2B-Instruct",     "Qwen/Qwen3-VL-2B-Instruct",     "bf16"),
+            ("Qwen3-VL-2B FP8",      "Qwen3-VL-2B-Instruct-FP8", "Qwen/Qwen3-VL-2B-Instruct-FP8", "fp8"),
+            ("Qwen3-VL-2B Thinking", "Qwen3-VL-2B-Thinking",     "Qwen/Qwen3-VL-2B-Thinking",     "bf16"),
+        ],
+        "nim": None,
+        "vllm_swap_flags": ["--allowed-local-media-path", "/tmp"],
+        "vllm_swap_env":   {},
+    },
+    "QW3-8B": {
+        "variants": [
+            ("Qwen3-VL-8B Instruct", "Qwen3-VL-8B-Instruct",     "Qwen/Qwen3-VL-8B-Instruct",     "bf16"),
+            ("Qwen3-VL-8B FP8",      "Qwen3-VL-8B-Instruct-FP8", "Qwen/Qwen3-VL-8B-Instruct-FP8", "fp8"),
+            ("Qwen3-VL-8B Thinking", "Qwen3-VL-8B-Thinking",     "Qwen/Qwen3-VL-8B-Thinking",     "bf16"),
+        ],
+        "nim": None,
+        "vllm_swap_flags": ["--allowed-local-media-path", "/tmp"],
+        "vllm_swap_env":   {},
+    },
+    "QW3-32B": {
+        "variants": [
+            ("Qwen3-VL-32B Instruct", "Qwen3-VL-32B-Instruct",     "Qwen/Qwen3-VL-32B-Instruct",     "bf16"),
+            ("Qwen3-VL-32B FP8",      "Qwen3-VL-32B-Instruct-FP8", "Qwen/Qwen3-VL-32B-Instruct-FP8", "fp8"),
+            ("Qwen3-VL-32B Thinking", "Qwen3-VL-32B-Thinking",     "Qwen/Qwen3-VL-32B-Thinking",     "bf16"),
+        ],
+        "nim": None,
+        "vllm_swap_flags": ["--allowed-local-media-path", "/tmp"],
+        "vllm_swap_env":   {},
+    },
+    # ── Nemotron-Nano-12B-v2-VL (gated — HF_TOKEN with nvidia org required) ──────
+    # vLLM-only: uses opencv backend + file:// video URL (not base64 frames).
+    # Requires vLLM nightly; PyPI vLLM ≤0.11.0 unsupported.
+    "NEM-12B": {
+        "variants": [
+            ("Nem-12B BF16", "NVIDIA-Nemotron-Nano-12B-v2-VL-BF16", "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16", "bf16"),
+            ("Nem-12B FP8",  "NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",  "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",  "fp8"),
+        ],
+        "nim": None,
+        # Required for hot-swap: opencv video decoder + file:// media path + flashinfer bypass.
+        "vllm_swap_flags": ["--allowed-local-media-path", "/tmp"],
+        "vllm_swap_env":   {"VLLM_VIDEO_LOADER_BACKEND": "opencv", "FLASHINFER_DISABLE_VERSION_CHECK": "1"},
+    },
+}
+
+# Per-model-size slider defaults shown in Advanced Settings when a checkpoint is selected.
+# fps/max_pixels that are None inherit the GPU-tier value from DEFAULT_FPS/DEFAULT_MAX_PIXELS.
+# Thinking variants get a max_tokens boost automatically in _ckpt_slider_defaults().
+_MODEL_SIZE_DEFAULTS = {
+    # file:// models (NEM-12B, QW3-*) — fps slider unused by vLLM; inherit GPU-tier fps
+    "NEM-12B":  {"max_tokens": 512},
+    "QW3-2B":   {"max_tokens": 512},
+    "QW3-8B":   {"max_tokens": 512},
+    "QW3-32B":  {"max_tokens": 1024},
+    # base64-frame models — fps controls extraction; set sensible per-size values
+    "2B":    {"fps": 2, "max_tokens": 512},
+    "8B":    {"fps": 2, "max_tokens": 512},
+    "32B":   {"fps": 1, "max_tokens": 512},
+    "C3-2B": {"fps": 2, "max_tokens": 512},
+    "C3-8B": {"fps": 2, "max_tokens": 512},
+    "C3-32B":  {"fps": 1, "max_tokens": 1024},
+    "C3-super":{"fps": 1, "max_tokens": 1024},
+}
+# Flat map: checkpoint UI label → MODEL_CONFIGS size key (built after MODEL_CONFIGS is complete)
+_LABEL_TO_MODEL_SIZE = {
+    label: size_key
+    for size_key, cfg in MODEL_CONFIGS.items()
+    for label, _, _, _ in cfg.get("variants", [])
+}
+
+MODEL_SIZE   = os.environ.get("MODEL_SIZE", "2B").upper()
+# .upper() normalises input but breaks mixed-case keys. Remap known exceptions.
+_MODEL_SIZE_FIX = {"C3-SUPER": "C3-super"}
+MODEL_SIZE = _MODEL_SIZE_FIX.get(MODEL_SIZE, MODEL_SIZE)
+if MODEL_SIZE not in MODEL_CONFIGS:
+    print(f"[ERROR] MODEL_SIZE={MODEL_SIZE} not supported. Use 2B, 8B, 32B, C3-2B, C3-8B, C3-32B, C3-super, NEM-12B, QW3-2B, QW3-8B, or QW3-32B."); sys.exit(1)
+
+# Model-size specific fps default for the UI slider (HF mode uses lower fps to bound prefill time)
+_UI_DEFAULT_FPS = _MODEL_SIZE_DEFAULTS.get(MODEL_SIZE, {}).get("fps", DEFAULT_FPS)
+
+# Hard cap on frames sampled in HF mode — prevents multi-minute prefills on long videos.
+# qwen_vl_utils respects "nframes" in the conversation dict to uniformly subsample the clip.
+_MAX_HF_FRAMES = 32
+
+_cfg         = MODEL_CONFIGS[MODEL_SIZE]
+_MODELS_BASE = os.path.join(HOME, "cosmos-reason2", "models")
+
+# Override MODEL_DIR/MODEL_NAME from size if not explicitly set
+if not os.environ.get("MODEL_DIR"):
+    MODEL_DIR  = os.path.join(_MODELS_BASE, _cfg["variants"][0][1])
+if not os.environ.get("MODEL_NAME"):
+    MODEL_NAME = _cfg["variants"][0][2]
+
+NIM_MODEL_API = _cfg["nim"] or ""
+
+def _resolve(dirname, hf_id):
+    local = os.path.join(_MODELS_BASE, dirname)
+    return local if os.path.exists(local) else hf_id
+
+def _ckpt_slider_defaults(label):
+    """Return (fps, max_pixels, max_tokens) for a checkpoint label.
+    Falls back to GPU-tier globals; Thinking variants get a max_tokens boost."""
+    size = _LABEL_TO_MODEL_SIZE.get(label, MODEL_SIZE)
+    ov   = _MODEL_SIZE_DEFAULTS.get(size, {})
+    fps  = ov.get("fps",        DEFAULT_FPS)
+    mpx  = ov.get("max_pixels", DEFAULT_MAX_PIXELS)
+    mtok = ov.get("max_tokens", DEFAULT_MAX_TOKENS)
+    if "Think" in label:
+        mtok = max(mtok, 1024)
+    return fps, mpx, mtok
+
+CHECKPOINT_PRESETS = [
+    (label, _resolve(dirname, hf_id))
+    for label, dirname, hf_id, _ in _cfg["variants"]
+]
+# Always show NIM entry so the user gets an explicit result rather than silence
+_nim_api_id = _cfg["nim"] or ""
+CHECKPOINT_PRESETS.append((f"NIM {MODEL_SIZE}", f"nim://{_nim_api_id}"))
+
+# When running in NIM mode, the HF quantization variants (FP8 / NVFP4 / BF16)
+# are stale artifacts — the NIM container ships its own fixed quantization, so
+# all four entries collapse to the running NIM. Replace the dropdown with the
+# upstream VLM NIM catalog from
+#   https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html
+# (cross-referenced against KNOWN_VLM_NIMS in ~/.claude/scripts/nim_catalog.py).
+# We skip the docker-manifest probe at module-load to keep Gradio startup snappy
+# — probing happens at switch time when the user actually wants to swap models.
+_NIM_CATALOG = []
+if INFERENCE_BACKEND == "nim_local":
+    try:
+        # Catalog helper sits next to this script (and is also scp'd to /tmp/).
+        for _p in (os.path.dirname(os.path.abspath(__file__)), "/tmp"):
+            if _p and _p not in sys.path:
+                sys.path.insert(0, _p)
+        from nim_catalog import list_available_nims, KNOWN_VLM_NIMS  # type: ignore
+        _NIM_CATALOG = list_available_nims(
+            ngc_api_key=NGC_API_KEY,
+            vram_mb=None,           # don't VRAM-filter at startup; show everything supported
+            use_upstream=True,      # fetch docs.nvidia.com — this is the agent's source of truth
+            do_probe=False,         # probe lazily on switch (avoids 10-30s startup penalty)
+        )
+        if not _NIM_CATALOG:
+            # Network unreachable or upstream removed every family we know — fall
+            # back to the static slug map so the user is not stranded.
+            _NIM_CATALOG = list(KNOWN_VLM_NIMS)
+        # NO `nim://` prefix in nim_local mode — that prefix routes
+        # run_inference() to _run_nim_inference (the NVCF hosted-API path)
+        # which skips models like CR2-2B that are not in the public NVCF
+        # catalog. In nim_local mode the user wants the LOCAL Docker
+        # container, which is OpenAI-compatible and reached via
+        # _run_vllm_inference. Pass the served_model_id directly so
+        # _is_nim() returns False and routing falls through to the
+        # vLLM-style path against VLLM_BASE_URL=http://localhost:8000/v1.
+        CHECKPOINT_PRESETS = [(n.label, n.served_model_id) for n in _NIM_CATALOG]
+        print(f"[nim_local] catalog: {len(_NIM_CATALOG)} VLM NIMs from {len([n for n in _NIM_CATALOG])} entries", flush=True)
+    except Exception as _e:
+        print(f"[nim_local] catalog fetch failed ({_e}); keeping default presets", flush=True)
+
+# ── vLLM dropdown: all variants across all model sizes ─────────────────────────
+# In vLLM mode the checkpoint dropdown exposes every quantization across 2B/8B/32B.
+# _VLLM_DD_META maps label → (local_path, hf_id) so _on_checkpoint_change can
+# locate the model and pass the right served-model-name to _launch_vllm_swap.
+_ALL_VARIANTS_DD_RAW = [
+    ("C3R-2B BF16",   "Cosmos3-Reasoner-2B",                  "nvidia/Cosmos3-Reasoner-2B-Private",             "bf16"),
+    ("C3R-Nano BF16", "Cosmos3-Nano-Reasoner",                 "nvidia/Cosmos3-Nano-Reasoner",                   "bf16"),
+    ("C3R-32B BF16",  "Cosmos3-Reasoner-32B",                 "nvidia/Cosmos3-Reasoner-32B-Private",            "bf16"),
+    ("C3-Super BF16", "Cosmos3-Super-Reasoner",               "nvidia/Cosmos3-Super-Reasoner",                  "bf16"),
+    ("CR2-2B BF16",   "Cosmos-Reason2-2B",                    "nvidia/Cosmos-Reason2-2B",                       "bf16"),
+    ("CR2-2B FP8",    "Cosmos-Reason2-2B-FP8",                "nvidia/Cosmos-Reason2-2B-FP8",                   "fp8"),
+    ("CR2-2B NVFP4",  "Cosmos-Reason2-2B-NVFP4",              "nvidia/Cosmos-Reason2-2B-NVFP4",                 "nvfp4"),
+    ("CR2-8B BF16",   "Cosmos-Reason2-8B",                    "nvidia/Cosmos-Reason2-8B",                       "bf16"),
+    ("CR2-8B FP8",    "Cosmos-Reason2-8B-FP8",                "nvidia/Cosmos-Reason2-8B-FP8",                   "fp8"),
+    ("CR2-8B NVFP4",  "Cosmos-Reason2-8B-NVFP4",              "nvidia/Cosmos-Reason2-8B-NVFP4",                 "nvfp4"),
+    ("CR2-32B BF16",  "Cosmos-Reason2-32B",                   "nvidia/Cosmos-Reason2-32B",                      "bf16"),
+    ("CR2-32B AV",    "Cosmos-Reason2-32B-AV",                "nvidia/Cosmos-Reason2-32B-AV",                   "bf16"),
+    ("Nem-12B BF16",      "NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",  "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",    "bf16"),
+    ("Nem-12B FP8",       "NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",   "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8",     "fp8"),
+    # Qwen3-VL — public, no HF_TOKEN required; uses file:// video_url like Nemotron
+    ("Qwen3-VL-2B",       "Qwen3-VL-2B-Instruct",      "Qwen/Qwen3-VL-2B-Instruct",      "bf16"),
+    ("Qwen3-VL-2B FP8",   "Qwen3-VL-2B-Instruct-FP8",  "Qwen/Qwen3-VL-2B-Instruct-FP8",  "fp8"),
+    ("Qwen3-VL-2B Think", "Qwen3-VL-2B-Thinking",      "Qwen/Qwen3-VL-2B-Thinking",      "bf16"),
+    ("Qwen3-VL-8B",       "Qwen3-VL-8B-Instruct",      "Qwen/Qwen3-VL-8B-Instruct",      "bf16"),
+    ("Qwen3-VL-8B FP8",   "Qwen3-VL-8B-Instruct-FP8",  "Qwen/Qwen3-VL-8B-Instruct-FP8",  "fp8"),
+    ("Qwen3-VL-8B Think", "Qwen3-VL-8B-Thinking",      "Qwen/Qwen3-VL-8B-Thinking",      "bf16"),
+    ("Qwen3-VL-32B",      "Qwen3-VL-32B-Instruct",     "Qwen/Qwen3-VL-32B-Instruct",     "bf16"),
+    ("Qwen3-VL-32B FP8",  "Qwen3-VL-32B-Instruct-FP8", "Qwen/Qwen3-VL-32B-Instruct-FP8", "fp8"),
+    ("Qwen3-VL-32B Think","Qwen3-VL-32B-Thinking",     "Qwen/Qwen3-VL-32B-Thinking",     "bf16"),
+]
+_VLLM_DD_META = {
+    label: (os.path.join(_MODELS_BASE, dirname), hf_id)
+    for label, dirname, hf_id, _ in _ALL_VARIANTS_DD_RAW
+}
+if INFERENCE_BACKEND == "vllm":
+    CHECKPOINT_PRESETS = [
+        (label, _resolve(dirname, hf_id))
+        for label, dirname, hf_id, _ in _ALL_VARIANTS_DD_RAW
+    ]
+    CHECKPOINT_PRESETS.append(("NIM 8B", "nim://nvidia/cosmos-reason2-8b"))
+    # Auto-select the checkpoint that matches the loaded model so no swap fires on first use.
+    _VLLM_DD_MAP = {
+        "NEM-12B": "Nem-12B BF16",
+        "QW3-2B":  "Qwen3-VL-2B",
+        "QW3-8B":  "Qwen3-VL-8B",
+        "QW3-32B": "Qwen3-VL-32B",
+        "2B":      "CR2-2B BF16",
+        "8B":      "CR2-8B BF16",
+        "C3-2B":   "C3R-2B BF16",
+        "C3-8B":   "C3R-Nano BF16",
+        "C3-32B":  "C3R-32B BF16",
+        "C3-super":"C3-Super BF16",
+        "32B":     "CR2-32B BF16",
+    }
+    _VLLM_DD_DEFAULT = _VLLM_DD_MAP.get(MODEL_SIZE, "CR2-8B BF16")
+elif INFERENCE_BACKEND == "nim_local" and _NIM_CATALOG:
+    # Default to the currently-served NIM (whichever one the running container
+    # reports via /v1/models). If we can't match, fall back to first entry.
+    _matched = next(
+        (n.label for n in _NIM_CATALOG if n.served_model_id == (_SERVER_MODEL_ID or "")),
+        None,
+    )
+    _VLLM_DD_DEFAULT = _matched or CHECKPOINT_PRESETS[0][0]
+else:
+    _VLLM_DD_DEFAULT = CHECKPOINT_PRESETS[0][0]
+
+DEFAULT_SYSTEM = "You are a helpful assistant that analyzes videos."
+DEFAULT_PROMPT = "Describe what is happening in this video. What are the key actions, objects, and events?"
+
+_GENERIC_SYSTEM = "You are a helpful assistant."
+_WAREHOUSE_SYSTEM = "You are a helpful warehouse monitoring system."
+
+# (label, user_prompt, system_prompt, reasoning_on)
+# reasoning_on signals whether the prompt instructs the model to wrap its
+# chain-of-thought in <think>...</think>. The Gradio "Reasoning: ON/OFF"
+# badge reads this; the actual rendering of <think> blocks is handled by
+# _render_with_think() regardless.
+DEMO_PROMPTS = [
+    ("General description",
+     "Describe what is happening in this video. What are the key actions, objects, and events?",
+     DEFAULT_SYSTEM, False),
+    ("Safety analysis",
+     "Identify any safety hazards, risks, or unsafe behaviors visible in this video. Be specific.",
+     DEFAULT_SYSTEM, False),
+    ("Non-expert summary",
+     "Summarize this video in plain language for someone with no domain expertise.",
+     DEFAULT_SYSTEM, False),
+    ("Action recognition",
+     "List every distinct action or motion performed in this video, in the order they occur.",
+     DEFAULT_SYSTEM, False),
+    ("Object inventory",
+     "List all objects, equipment, and people visible. Note their state.",
+     DEFAULT_SYSTEM, False),
+    ("Anomaly detection",
+     "Identify anything unusual, unexpected, or out of place in this video.",
+     DEFAULT_SYSTEM, False),
+    ("Temporal summary",
+     "Break this video into time segments and describe what changes in each segment.",
+     DEFAULT_SYSTEM, False),
+
+    # ── Cosmos Reason2 reasoning showcases (mirror build.nvidia.com) ───────────
+    ("Race car: timestamps",
+     "Describe the video. Add timestamps in mm:ss format.\n\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag and "
+     "include the timestamps.",
+     _GENERIC_SYSTEM, True),
+    ("Forklift: load weight (JSON)",
+     "Locate the bounding box of the load and determine if its size and "
+     "weight of load within the forklift's limits. Estimate weights. "
+     "Return all as json. Include json location, estimated weight of the "
+     "load, and if it's in the limit.",
+     _GENERIC_SYSTEM, False),
+    ("Mail package: pickup allowed?",
+     "Is the person allowed to pick up the packages?\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag.",
+     _GENERIC_SYSTEM, True),
+    ("Warehouse: who picked up the box?",
+     "Which worker picked up the dropped box?\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag.",
+     _WAREHOUSE_SYSTEM, True),
+    ("AV: next ego action",
+     "What's the next immediate action for the Ego vehicle?\n\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag.",
+     _GENERIC_SYSTEM, True),
+    ("Robot arm: 2D trajectory (JSON)",
+     "You are given the task \"Move the tape into the basket\". Specify "
+     "the 2D trajectory your end effector should follow in pixel space. "
+     "Return the trajectory coordinates in JSON format like this: "
+     "{\"point_2d\": [x, y], \"label\": \"gripper trajectory\"}.\n\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag.",
+     _GENERIC_SYSTEM, True),
+    ("SDG critic: approve / reject",
+     "Approve or reject this generated video for inclusion in a dataset "
+     "for physical world model ai training. It must perfectly adhere to "
+     "physics, object permanence, and have no anomalies. Any issue or "
+     "concern causes rejection.\n"
+     "Answer the question using the following format:\n\n"
+     "<think>\nYour reasoning.\n</think>\n\n"
+     "Write your final answer immediately after the </think> tag. "
+     "Answer with Approve or Reject only.",
+     _GENERIC_SYSTEM, True),
+]
+
+
+def _reasoning_badge_html(reasoning_on):
+    """Inline pill rendered above the response area. NV-green for ON,
+    slate-300 for OFF — both readable on Gradio's light theme."""
+    if reasoning_on:
+        return (
+            '<div style="display:inline-flex;align-items:center;gap:6px;'
+            'background:#76b900;color:#0f172a;padding:4px 12px;'
+            'border-radius:14px;font-size:0.85em;font-weight:600;'
+            'margin-bottom:6px">🧠 Reasoning: ON</div>'
+        )
+    return (
+        '<div style="display:inline-flex;align-items:center;gap:6px;'
+        'background:#cbd5e1;color:#0f172a;padding:4px 12px;'
+        'border-radius:14px;font-size:0.85em;font-weight:600;'
+        'margin-bottom:6px">○ Reasoning: OFF</div>'
+    )
+
+HF_STEPS = [
+    "Resolve checkpoint & GPU",
+    "Load model weights",
+    "Preprocess video frames",
+    "Prefill tokens",
+    "Generate response",
+]
+
+NIM_STEPS = [
+    "Resolve checkpoint & GPU",
+    "Validate NGC API key",
+    "Extract video frames",
+    "Send to NVCF endpoint",
+    "Stream response",
+]
+
+VLLM_STEPS = [
+    "Resolve checkpoint & GPU",
+    "Check vLLM server",
+    "Extract video frames",
+    "Send to vLLM endpoint",
+    "Stream response",
+]
+
+# ── Global model state ─────────────────────────────────────────────────────────
+_state_lock = threading.Lock()
+_loaded = {
+    "model":          None,
+    "processor":      None,
+    "model_id":       None,
+    "load_time":      0.0,
+    "upcast_warning": None,   # set when HF silently upcasts quantized weights to bf16
+}
+
+# ── Run log (persists across Gradio calls) ─────────────────────────────────────
+_run_log: list = []
+_log_lock = threading.Lock()
+
+
+# ── Pure helpers ───────────────────────────────────────────────────────────────
+def _est_tokens(n_frames, max_pixels):
+    return int(n_frames * max_pixels / _BASELINE_PX * _EMPIRICAL_VPF) + TEXT_TOKENS
+
+
+def _auto_cap(n_frames, current_max_pixels):
+    for px in reversed(_PIXEL_TIERS):
+        if px > current_max_pixels:
+            continue
+        est_s = _est_tokens(n_frames, px) / PREFILL_TPS
+        if est_s <= TARGET_INFER_S:
+            return px, est_s
+    px = _PIXEL_TIERS[0]
+    return px, _est_tokens(n_frames, px) / PREFILL_TPS
+
+
+def get_video_meta(path):
+    class _M:
+        width = height = fps = duration_s = 0
+    m = _M()
+    if not _AV_OK or not path:
+        return m
+    try:
+        container = _av_module.open(path)
+        stream = next((s for s in container.streams if s.type == "video"), None)
+        if stream:
+            m.width      = stream.width
+            m.height     = stream.height
+            m.fps        = float(stream.average_rate) if stream.average_rate else 0.0
+            m.duration_s = float(container.duration) / 1_000_000 if container.duration else 0.0
+        container.close()
+    except Exception:
+        pass
+    return m
+
+
+def get_free_vram_mib():
+    try:
+        return torch.cuda.mem_get_info()[0] // (1024 * 1024)
+    except Exception:
+        return 0
+
+
+def _is_nim(model_id):
+    return model_id.startswith("nim://")
+
+def _is_vllm(model_id):
+    return INFERENCE_BACKEND in ("vllm", "nim_local") and not _is_nim(model_id)
+
+def _is_nemotron(model_id):
+    """True for Nemotron models — they use file:// video URL instead of base64 frames."""
+    return "nemotron" in (model_id or "").lower()
+
+def _is_qwen3vl(model_id):
+    """True for Qwen3-VL models — they use file:// video URL (same as Nemotron)."""
+    mid = (model_id or "").lower()
+    return "qwen3-vl" in mid or "qwen3vl" in mid
+
+def _uses_file_url(model_id):
+    """True for any model that uses file:// video URL to vLLM (vs base64 JPEG frames)."""
+    return _is_nemotron(model_id) or _is_qwen3vl(model_id)
+
+def _expected_quant(model_id):
+    """Infer expected quantization from model path/ID name."""
+    mid = model_id.lower()
+    if "nvfp4" in mid or ("-fp4" in mid and "nvidia" in mid):
+        return "nvfp4"
+    if "fp8" in mid:
+        return "fp8"
+    return "bf16"
+
+
+# ── Reasoning panel (build.nvidia.com style) ─────────────────────────────────
+# Cosmos Reason 2 emits its chain-of-thought between <think>...</think> tags
+# inside the streamed `delta.content`. Mirrors build.nvidia.com's UI: a
+# collapsible "Reasoning Complete ✓" header above the final answer; while
+# tokens are still streaming inside <think>, the header reads "Reasoning…"
+# and stays expanded so the user can watch the model think.
+_REASONING_PANEL_CSS = """
+/* Self-contained dark wrapper so contrast holds regardless of Gradio
+   theme (light/dark). Mirrors build.nvidia.com's reasoning panel. */
+.cr-output {
+  padding: 14px 16px;
+  font-size: 0.95em;
+  line-height: 1.5;
+  max-height: 540px;
+  overflow-y: auto;
+  background: #0f172a;          /* slate-900 — guarantees dark backdrop */
+  color: #f1f5f9;               /* slate-100 — default text on the wrapper */
+  border-radius: 8px;
+  border: 1px solid #334155;    /* slate-700 — visible edge on light themes */
+}
+.cr-prelude {
+  white-space: pre-wrap;
+  color: #cbd5e1;               /* slate-300 */
+  padding: 4px 0;
+  font-style: italic;
+  font-size: 0.92em;
+}
+.cr-reasoning {
+  border: 1px solid #76b900;    /* NV green */
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  background: rgba(118,185,0,0.10);
+}
+.cr-reasoning summary {
+  cursor: pointer;
+  color: #76b900;
+  font-weight: 600;
+  user-select: none;
+  list-style: none;
+  padding: 2px 0;
+  font-size: 0.95em;
+}
+.cr-reasoning summary::-webkit-details-marker { display: none; }
+.cr-reasoning summary::before { content: '▸ '; color: #76b900; font-size: 0.9em; }
+.cr-reasoning[open] summary::before { content: '▾ '; }
+.cr-reasoning .cr-reasoning-blurb {
+  color: #94a3b8;               /* slate-400 */
+  font-size: 0.85em;
+  margin: 6px 0 8px 0;
+  font-style: italic;
+}
+.cr-reasoning .cr-think-body {
+  white-space: pre-wrap;
+  color: #e2e8f0;               /* slate-200 — clearly readable on dark */
+  padding: 6px 10px;
+  border-left: 2px solid #76b900;
+  font-size: 0.92em;
+  background: rgba(15,23,42,0.5);
+  border-radius: 0 4px 4px 0;
+}
+.cr-answer {
+  white-space: pre-wrap;
+  color: #f8fafc;               /* slate-50 — brightest, the headline output */
+  padding: 8px 0 4px 0;
+  font-size: 1.02em;
+  font-weight: 500;
+}
+"""
+
+
+def _render_with_think(text):
+    """Split streamed model output on <think>...</think> and render the
+    reasoning as a collapsible panel + the answer plainly below.
+    Plain text (no <think>) renders as-is. Streaming mid-think shows a
+    "Reasoning…" header (open by default); once </think> arrives the
+    header switches to "Reasoning Complete ✓" and collapses by default.
+    Always returns HTML safe for gr.HTML — escapes user-visible text."""
+    import html as _html
+    if not text:
+        return "<div class='cr-output'></div>"
+    open_tag, close_tag = "<think>", "</think>"
+    i_open = text.find(open_tag)
+    if i_open < 0:
+        return f"<div class='cr-output'><div class='cr-answer'>{_html.escape(text)}</div></div>"
+    pre = text[:i_open]
+    body_start = i_open + len(open_tag)
+    i_close = text.find(close_tag, body_start)
+    if i_close < 0:
+        reasoning = text[body_start:]
+        summary = "⏳ Reasoning…"
+        details_open = " open"
+        answer_html = ""
+        blurb = "<div class='cr-reasoning-blurb'>The model is thinking… stream continues below.</div>"
+    else:
+        reasoning = text[body_start:i_close]
+        post = text[i_close + len(close_tag):].lstrip("\n")
+        summary = "✓ Reasoning Complete"
+        details_open = ""
+        answer_html = f"<div class='cr-answer'>{_html.escape(post)}</div>" if post else ""
+        blurb = "<div class='cr-reasoning-blurb'>Below is the entire thinking process the model went through to arrive at its response.</div>"
+    pre_html = f"<div class='cr-prelude'>{_html.escape(pre)}</div>" if pre.strip() else ""
+    reasoning_html = (
+        f"<details{details_open} class='cr-reasoning'>"
+        f"<summary>{summary}</summary>"
+        f"{blurb}"
+        f"<div class='cr-think-body'>{_html.escape(reasoning)}</div>"
+        f"</details>"
+    )
+    return f"<div class='cr-output'>{pre_html}{reasoning_html}{answer_html}</div>"
+
+
+def _status_html(statuses, metrics=None, steps=None):
+    """
+    statuses : list of 5 strings — "ok" | "run" | "wait"
+    metrics  : optional dict with keys: model_id, load_s, tokens_in, tokens_out,
+               ttft_s, infer_s, elapsed_s
+    steps    : optional list of 5 step label strings (defaults to HF_STEPS)
+    """
+    if steps is None:
+        steps = HF_STEPS
+
+    ICON  = {"ok": "✅", "run": "⟳", "wait": "—"}
+    COLOR = {"ok": "#4CAF50", "run": "#FFA500", "wait": "#fff"}
+
+    rows = ""
+    for i, (label, st) in enumerate(zip(steps, statuses)):
+        icon  = ICON[st]
+        color = COLOR[st]
+        weight = "bold" if st == "run" else "normal"
+        rows += (
+            f'<div style="color:{color};font-weight:{weight};margin:3px 0">'
+            f'<b>Step {i+1}/5:</b> {label} &nbsp;{icon}'
+            f'</div>'
+        )
+
+    mhtml = ""
+    if metrics:
+        mhtml = '<hr style="margin:8px 0;border:none;border-top:1px solid #555"/>'
+        # Backend badge
+        _be = metrics.get("backend", INFERENCE_BACKEND.upper())
+        _be_color = "#a78bfa" if _be == "VLLM" else ("#7dd3fc" if _be == "NIM" else "#86efac")
+        mhtml += (f'<div style="margin:2px 0;color:#fff">🔧 <b>Backend:</b> '
+                  f'<code style="font-size:11px;color:{_be_color}">{_be}</code></div>')
+        if metrics.get("elapsed_s") is not None:
+            mhtml += f'<div style="margin:2px 0;color:#fff">⏱ <b>Elapsed:</b> {metrics["elapsed_s"]:.1f}s</div>'
+        if metrics.get("model_id"):
+            mid   = metrics["model_id"]
+            short = mid.split("/")[-1] if "/" in mid else mid
+            mhtml += f'<div style="margin:2px 0;color:#fff">🤖 <code style="font-size:11px;color:#7dd3fc">{short}</code></div>'
+        if metrics.get("upcast_warning"):
+            mhtml += (f'<div style="margin:4px 0;color:#fbbf24;font-size:11px">'
+                      f'⚠ {metrics["upcast_warning"]}</div>')
+        if metrics.get("load_s") is not None:
+            mhtml += f'<div style="margin:2px 0;color:#fff">🔄 <b>Load:</b> {metrics["load_s"]:.1f}s</div>'
+        if metrics.get("tokens_in"):
+            mhtml += f'<div style="margin:2px 0;color:#fff">📥 <b>Prefill:</b> {metrics["tokens_in"]:,} tokens</div>'
+        if metrics.get("tokens_out") is not None:
+            mhtml += f'<div style="margin:2px 0;color:#fff">📤 <b>Generated:</b> {metrics["tokens_out"]:,} tokens</div>'
+        if metrics.get("ttft_s") is not None:
+            mhtml += f'<div style="margin:2px 0;color:#fff">⚡ <b>TTFT:</b> {metrics["ttft_s"]:.2f}s</div>'
+        if metrics.get("infer_s") is not None:
+            mhtml += f'<div style="margin:2px 0;color:#fff">⏱ <b>Inference:</b> {metrics["infer_s"]:.1f}s</div>'
+
+    return (
+        '<div style="font-family:monospace;font-size:13px;line-height:1.6;'
+        'padding:10px;background:#1a1a1a;border-radius:6px;color:#fff">'
+        + rows + mhtml + '</div>'
+    )
+
+
+def _table_html():
+    """Render _run_log as a dark HTML benchmark table."""
+    TH = ('style="padding:6px 10px;text-align:left;border-bottom:1px solid #444;'
+          'color:#7dd3fc;white-space:nowrap"')
+    TD = 'style="padding:5px 10px;border-bottom:1px solid #333;color:#fff;white-space:nowrap"'
+    with _log_lock:
+        log = list(_run_log)
+    if not log:
+        return ('<div style="font-family:monospace;font-size:12px;color:#888;'
+                'padding:10px;background:#1a1a1a;border-radius:6px">'
+                'No runs logged yet.</div>')
+    cols = ["Model", "Load (s)", "TTFT (s)", "Infer (s)", "Tokens Out", "Total (s)", "Status", "Notes"]
+    hdr = "".join(f"<th {TH}>{c}</th>" for c in cols)
+    rows_html = ""
+    for r in log:
+        def _f(v, fmt=".1f"):
+            return f"{v:{fmt}}" if v is not None else "—"
+        notes_val = r.get("notes", "")
+        notes_html = (
+            f'<span style="color:#fbbf24;font-size:11px">⚠ {notes_val}</span>'
+            if notes_val else "—"
+        )
+        cells = [
+            r.get("model", "—"),
+            _f(r.get("load_s")),
+            _f(r.get("ttft_s"), ".2f"),
+            _f(r.get("infer_s")),
+            str(r.get("tokens_out") or "—"),
+            _f(r.get("total_s")),
+            r.get("status", "—"),
+            notes_html,
+        ]
+        _TD_WIDE = 'style="padding:5px 10px;border-bottom:1px solid #333;color:#fff;white-space:normal;max-width:260px"'
+        row_tds = [f"<td {TD}>{c}</td>" for c in cells[:-1]]
+        row_tds.append(f"<td {_TD_WIDE}>{cells[-1]}</td>")
+        rows_html += "<tr>" + "".join(row_tds) + "</tr>"
+    return (
+        '<div style="overflow-x:auto;margin-top:10px">'
+        '<table style="width:100%;border-collapse:collapse;font-family:monospace;'
+        'font-size:12px;background:#1a1a1a;border-radius:6px">'
+        f"<thead><tr>{hdr}</tr></thead><tbody>{rows_html}</tbody></table></div>"
+    )
+
+
+def _log_run(model_id, load_s=None, ttft_s=None, infer_s=None,
+             tokens_out=None, total_s=None, status="ok", notes=None, display_label=None):
+    if display_label:
+        short = display_label
+    elif model_id.startswith("nim://"):
+        short = f"NIM-{MODEL_SIZE}"
+    else:
+        short = model_id.split("/")[-1] if "/" in model_id else model_id
+    with _log_lock:
+        _run_log.append({
+            "model": short, "load_s": load_s, "ttft_s": ttft_s,
+            "infer_s": infer_s, "tokens_out": tokens_out,
+            "total_s": total_s, "status": status, "notes": notes or "",
+        })
+
+
+# ── Model load / unload ────────────────────────────────────────────────────────
+def _unload():
+    global _loaded
+    with _state_lock:
+        if _loaded["model"] is None:
+            return
+        mid = _loaded["model_id"]
+        print(f"[model] Unloading {mid}", flush=True)
+        del _loaded["model"]
+        del _loaded["processor"]
+        _loaded["model"]          = None
+        _loaded["processor"]      = None
+        _loaded["model_id"]       = None
+        _loaded["load_time"]      = 0.0
+        _loaded["upcast_warning"] = None
+        gc.collect()
+        torch.cuda.empty_cache()
+        free = get_free_vram_mib()
+        print(f"[model] Unloaded. VRAM free: {free:,} MiB", flush=True)
+
+
+def _load(model_id):
+    """Load an HF checkpoint. Unloads current if different. Returns (model, processor, load_time_s)."""
+    global _loaded
+    with _state_lock:
+        if _loaded["model_id"] == model_id and _loaded["model"] is not None:
+            return _loaded["model"], _loaded["processor"], _loaded["load_time"]
+
+        if _loaded["model"] is not None:
+            print(f"[model] Switching {_loaded['model_id']} → {model_id}", flush=True)
+            del _loaded["model"]
+            del _loaded["processor"]
+            _loaded["model"]     = None
+            _loaded["processor"] = None
+            _loaded["model_id"]  = None
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        print(f"[model] Loading {model_id} ...", flush=True)
+        t0 = time.time()
+
+        # BUG-001 fix: detect model_type from config.json so NemotronVL (nemotron_siglip2)
+        # and other non-qwen3_vl architectures route to AutoModelForCausalLM instead of
+        # Qwen3VLForConditionalGeneration, which raises NotImplementedError for unknown archs.
+        _model_type = "qwen3_vl"
+        _config_path = os.path.join(model_id, "config.json") if os.path.isdir(model_id) else ""
+        if _config_path and os.path.exists(_config_path):
+            with open(_config_path) as _cf:
+                _model_type = json.load(_cf).get("model_type", "qwen3_vl")
+
+        kwargs = dict(dtype="auto", device_map="auto")
+        if HF_TOKEN:
+            kwargs["token"] = HF_TOKEN
+
+        if _model_type == "qwen3_vl":
+            kwargs["attn_implementation"] = "sdpa"
+            model = Qwen3VLForConditionalGeneration.from_pretrained(model_id, **kwargs)
+        else:
+            kwargs["trust_remote_code"] = True
+            print(f"[model] model_type={_model_type!r} — using AutoModelForCausalLM", flush=True)
+            model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
+
+        proc_kwargs = {"trust_remote_code": True}
+        if HF_TOKEN:
+            proc_kwargs["token"] = HF_TOKEN
+        processor = AutoProcessor.from_pretrained(model_id, **proc_kwargs)
+
+        load_time = time.time() - t0
+
+        dtype_str = str(next(model.parameters()).dtype)
+
+        # Detect silent upcasting: quantized checkpoint loaded as bf16 by HF transformers
+        upcast_warning = None
+        expected = _expected_quant(model_id)
+        if expected == "fp8" and "float8" not in dtype_str:
+            upcast_warning = (f"FP8 weights upcast to {dtype_str} — "
+                              f"HF has no FP8 compute kernels. Use vLLM for real FP8 speed.")
+        elif expected == "nvfp4" and "float4" not in dtype_str:
+            upcast_warning = (f"NVFP4 weights upcast to {dtype_str} — "
+                              f"NVFP4 requires TRT-LLM or NIM; HF runs at BF16 speed.")
+        elif expected == "bf16" and "float32" in dtype_str and _model_type != "qwen3_vl":
+            # BUG-006: NemotronVL and other non-qwen3_vl models may load as float32
+            # when transformers version doesn't honor dtype="auto" for the architecture.
+            upcast_warning = (f"BF16 model loaded as float32 (arch={_model_type!r}) — "
+                              f"2× memory usage. Set torch_dtype=torch.bfloat16 if OOM.")
+        if upcast_warning:
+            print(f"[upcast] {upcast_warning}", flush=True)
+
+        _loaded["model"]          = model
+        _loaded["processor"]      = processor
+        _loaded["model_id"]       = model_id
+        _loaded["load_time"]      = load_time
+        _loaded["upcast_warning"] = upcast_warning
+
+        print(
+            f"[model] Ready in {load_time:.1f}s | dtype={dtype_str} | "
+            f"VRAM free: {get_free_vram_mib():,} MiB",
+            flush=True,
+        )
+        return model, processor, load_time
+
+
+# ── Frame extraction for NIM ───────────────────────────────────────────────────
+def _extract_frames_b64(video_path, fps=1, max_frames=8):
+    """Return list of base64 JPEG strings sampled from `video_path`.
+
+    Sampling strategy:
+      - target_count = duration_s * fps (what fps would yield without a cap)
+      - if target_count <= max_frames: pick every `frame_rate/fps`-th frame
+        starting at 0. Behaviour identical to the prior version.
+      - if target_count > max_frames: uniformly distribute `max_frames` picks
+        across the FULL video duration (frame indices spaced by
+        (total_frames-1)/(max_frames-1)). This is the critical fix for
+        long clips where the cap previously truncated everything to the
+        first ~max_frames/fps seconds, e.g. for a 30-fps 40-s clip with
+        fps=8 max=5 the prior logic took only the first 0.4 s of footage.
+    """
+    if not _AV_OK:
+        return []
+    try:
+        container = _av_module.open(video_path)
+        stream = container.streams.video[0]
+        frame_rate = float(stream.average_rate) or 25.0
+
+        # PyAV's stream.frames is reliable for most container formats; fall
+        # back to duration*rate when it's 0 (some streaming codecs).
+        total_frames = int(stream.frames or 0)
+        if total_frames <= 0:
+            duration_s = float(stream.duration * stream.time_base) if stream.duration else 0.0
+            total_frames = max(1, int(duration_s * frame_rate))
+
+        # How many frames the requested sample fps would produce if no cap.
+        target_count = max(1, int(round(total_frames * (fps / frame_rate))))
+
+        if target_count <= max_frames:
+            # Below the cap — take every Nth frame from the start (fps == sample fps).
+            interval = max(1, int(round(frame_rate / fps)))
+            target_indices = set(range(0, total_frames, interval))
+            n_to_take = max_frames
+        else:
+            # Hit the cap — distribute uniformly across the full video.
+            n_to_take = max_frames
+            if n_to_take == 1:
+                target_indices = {0}
+            else:
+                target_indices = {
+                    int(round(j * (total_frames - 1) / (n_to_take - 1)))
+                    for j in range(n_to_take)
+                }
+
+        frames = []
+        for i, frame in enumerate(container.decode(stream)):
+            if i in target_indices:
+                img = frame.to_image().convert("RGB")
+                buf = io.BytesIO()
+                img.save(buf, format="JPEG", quality=80)
+                frames.append(base64.b64encode(buf.getvalue()).decode())
+                if len(frames) >= n_to_take:
+                    break
+        container.close()
+        return frames
+    except Exception as e:
+        print(f"[warn] frame extraction failed: {e}", flush=True)
+        return []
+
+
+# ── vLLM inference (OpenAI-compatible local server) ───────────────────────────
+def _run_vllm_inference(video_path, prompt, system, fps, max_tokens, model_id, t_run_start=None, display_label=None, extra_note=None, is_image=False, temperature=0.0, top_p=1.0, rep_penalty=1.0):
+    """Generator: (response_text, status_html, table_html) via local vLLM/NIM server."""
+    steps = VLLM_STEPS
+    if t_run_start is None:
+        t_run_start = time.time()
+    _be_label = "NIM" if INFERENCE_BACKEND == "nim_local" else "VLLM"
+
+    # NIM-8B-FP8-THINK-EOS safety net: at greedy decode the FP8 model emits
+    # `<think>` then an EOS-like token, finishing in 2-3 tokens with no answer.
+    # Clamp to a small positive temperature to break the deterministic trap.
+    if INFERENCE_BACKEND == "nim_local" and temperature < 0.3:
+        print(f"[nim_local] Clamping temperature {temperature} → 0.3 (NIM-8B-FP8 <think>+EOS bug at greedy decode)", flush=True)
+        temperature = 0.3
+
+    def _elapsed():
+        return time.time() - t_run_start
+
+    # Step 1
+    yield "", _status_html(["run", "wait", "wait", "wait", "wait"],
+                           {"elapsed_s": _elapsed(), "backend": _be_label}, steps=steps), gr.update()
+
+    if not _REQUESTS_OK:
+        msg = "[vLLM] Skipped — requests library not installed"
+        _log_run(model_id, total_s=_elapsed(), status="skipped-no-requests", display_label=display_label)
+        yield msg, _status_html(["ok", "wait", "wait", "wait", "wait"],
+                                {"elapsed_s": _elapsed(), "backend": _be_label}, steps=steps), _table_html()
+        return
+
+    # Step 2: ping server
+    endpoint = f"{VLLM_BASE_URL}/chat/completions"
+    print(f"[vllm] endpoint={endpoint} model={model_id}", flush=True)
+    yield "", _status_html(["ok", "ok", "run", "wait", "wait"],
+                           {"model_id": model_id, "elapsed_s": _elapsed(), "backend": _be_label},
+                           steps=steps), gr.update()
+
+    # Step 3: prepare media content
+    # Images: single image_url (file:// for Nemotron/Qwen, base64 for CR2/C3).
+    # Videos: Nemotron/Qwen3-VL use file:// video_url; CR2/C3 use base64 JPEG frames.
+    _nem = _uses_file_url(model_id) or _uses_file_url(_SERVER_MODEL_ID or "")
+    if is_image:
+        if _nem:
+            content = [
+                {"type": "image_url", "image_url": {"url": f"file://{video_path}"}},
+                {"type": "text", "text": prompt},
+            ]
+            print(f"[vllm/image] file:// image: {video_path}", flush=True)
+        else:
+            try:
+                from PIL import Image as _pil_img
+                _img = _pil_img.open(video_path).convert("RGB")
+                _buf = io.BytesIO()
+                _img.save(_buf, format="JPEG", quality=85)
+                _img_b64 = base64.b64encode(_buf.getvalue()).decode()
+            except Exception as _img_err:
+                msg = f"[vLLM ERROR] Could not read image: {_img_err}"
+                _log_run(model_id, total_s=_elapsed(), status="image-error", display_label=display_label)
+                yield msg, _status_html(["ok", "ok", "wait", "wait", "wait"],
+                                        {"elapsed_s": _elapsed(), "backend": _be_label}, steps=steps), _table_html()
+                return
+            content = [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{_img_b64}"}},
+            ]
+            print(f"[vllm/image] base64 image prepared", flush=True)
+    elif _nem:
+        import shutil as _shutil
+        _nem_path = "/tmp/gradio_upload.mp4"
+        try:
+            if os.path.abspath(video_path) != os.path.abspath(_nem_path):
+                _shutil.copy2(video_path, _nem_path)
+        except Exception as _cp_err:
+            _nem_path = video_path  # fall back to original path if copy fails
+            print(f"[vllm/nemotron] copy to /tmp failed ({_cp_err}), using original path", flush=True)
+        content = [
+            {"type": "video_url", "video_url": {"url": f"file://{_nem_path}"}},
+            {"type": "text", "text": prompt},
+        ]
+        print(f"[vllm/nemotron] video_url: file://{_nem_path}", flush=True)
+    else:
+        # NIM container hard-caps at 5 images/prompt; vLLM has no such cap.
+        _max_frames = 5 if INFERENCE_BACKEND == "nim_local" else 8
+        print(f"[vllm] Extracting frames fps={fps} max={_max_frames}", flush=True)
+        frames_b64 = _extract_frames_b64(video_path, fps=fps, max_frames=_max_frames)
+        if not frames_b64:
+            msg = "[vLLM ERROR] Could not extract frames (PyAV missing or video unreadable)"
+            _log_run(model_id, total_s=_elapsed(), status="frame-error", display_label=display_label)
+            yield msg, _status_html(["ok", "ok", "wait", "wait", "wait"],
+                                    {"elapsed_s": _elapsed(), "backend": _be_label}, steps=steps), _table_html()
+            return
+        print(f"[vllm] {len(frames_b64)} frames extracted", flush=True)
+        content = [{"type": "text", "text": f"[Video — {len(frames_b64)} frames at {fps}fps]\n{prompt}"}]
+        for fb64 in frames_b64:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{fb64}"},
+            })
+
+    # Step 4: send to vLLM
+
+    yield "", _status_html(["ok", "ok", "ok", "run", "wait"],
+                            {"model_id": model_id, "elapsed_s": _elapsed(), "backend": _be_label},
+                            steps=steps), gr.update()
+
+    t_start = time.time()
+    try:
+        resp = _requests.post(
+            endpoint,
+            headers={"Authorization": f"Bearer {VLLM_API_KEY}", "Content-Type": "application/json"},
+            json={
+                "model": model_id,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user",   "content": content},
+                ],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "repetition_penalty": rep_penalty,
+                "stream": True,
+            },
+            stream=True,
+            timeout=180,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        e_str = str(e)
+        if "Connection refused" in e_str or "Failed to establish" in e_str or "ConnectionError" in type(e).__name__:
+            if INFERENCE_BACKEND == "nim_local":
+                err = (
+                    f"[NIM] Container not responding at {VLLM_BASE_URL}\n\n"
+                    "Start the NIM container first:\n"
+                    "  bash /tmp/nim_launch.sh <NGC_API_KEY> [HF_TOKEN]\n\n"
+                    "Or manually:\n"
+                    "  docker run -d --gpus all --shm-size=16GB -p 8000:8000 \\\n"
+                    "    -e NGC_API_KEY=<key> nvcr.io/nim/nvidia/cosmos-reason2-2b:latest\n\n"
+                    "Check status: docker logs cosmos-nim\n"
+                    "Check ready: curl http://localhost:8000/v1/models"
+                )
+            else:
+                err = (
+                    f"[vLLM] Server not running at {VLLM_BASE_URL}\n\n"
+                    "Restart vLLM on the instance, then retry:\n"
+                    f"  vllm serve <model-path> --served-model-name <model-id> "
+                    "--port 8000 --dtype auto --trust-remote-code --max-model-len 8192"
+                )
+        else:
+            err = f"[{_be_label} ERROR] {e}"
+        print(err, flush=True)
+        _log_run(model_id, total_s=_elapsed(), status="api-error", display_label=display_label)
+        yield err, _status_html(["ok", "ok", "ok", "wait", "wait"],
+                                 {"model_id": model_id, "elapsed_s": _elapsed(), "backend": _be_label},
+                                 steps=steps), _table_html()
+        return
+
+    # Step 5: stream
+    parts          = []
+    ttft_s         = None
+    tokens_decoded = 0
+
+    for line in resp.iter_lines():
+        if not line:
+            continue
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+        if not line.startswith("data: "):
+            continue
+        data = line[6:]
+        if data == "[DONE]":
+            break
+        try:
+            delta = json.loads(data)["choices"][0]["delta"].get("content", "")
+        except (json.JSONDecodeError, KeyError, IndexError):
+            continue
+        if delta:
+            if ttft_s is None:
+                ttft_s = time.time() - t_start
+            parts.append(delta)
+            tokens_decoded += 1
+            yield "".join(parts), _status_html(
+                ["ok", "ok", "ok", "ok", "run"],
+                {"model_id": model_id, "tokens_out": tokens_decoded,
+                 "ttft_s": ttft_s, "elapsed_s": _elapsed(), "backend": _be_label},
+                steps=steps,
+            ), gr.update()
+
+    infer_time = time.time() - t_start
+    response   = "".join(parts)
+    total_s    = _elapsed()
+    print(f"[vllm done] {infer_time:.1f}s · {tokens_decoded} tok out", flush=True)
+    _log_run(model_id, ttft_s=ttft_s, infer_s=infer_time,
+             tokens_out=tokens_decoded, total_s=total_s, status="ok",
+             display_label=display_label, notes=extra_note or "")
+    yield response, _status_html(
+        ["ok", "ok", "ok", "ok", "ok"],
+        {"model_id": model_id, "tokens_out": tokens_decoded, "ttft_s": ttft_s,
+         "infer_s": infer_time, "elapsed_s": total_s, "backend": _be_label},
+        steps=steps,
+    ), _table_html()
+
+
+# ── NIM inference ──────────────────────────────────────────────────────────────
+def _run_nim_inference(video_path, prompt, system, fps, max_tokens, model_id, t_run_start=None, display_label=None, is_image=False):
+    """Generator: (response_text, status_html, table_html) via NVCF streaming API."""
+    steps = NIM_STEPS
+    if t_run_start is None:
+        t_run_start = time.time()
+
+    def _elapsed():
+        return time.time() - t_run_start
+
+    # Step 1
+    yield "", _status_html(["run", "wait", "wait", "wait", "wait"],
+                           {"elapsed_s": _elapsed()}, steps=steps), gr.update()
+
+    if not _REQUESTS_OK:
+        msg = "[NIM] Skipped — requests library not installed"
+        _log_run(model_id, total_s=_elapsed(), status="skipped-no-requests", display_label=display_label)
+        yield msg, _status_html(
+            ["ok", "wait", "wait", "wait", "wait"],
+            {"elapsed_s": _elapsed()}, steps=steps
+        ), _table_html()
+        return
+
+    if not NIM_MODEL_API:
+        msg = (f"[NIM] Skipped — {MODEL_SIZE} not in public NVCF catalog. "
+               f"Ask DLAlgo team for internal NIM access.")
+        _log_run(model_id, total_s=_elapsed(), status="skipped-no-catalog", display_label=display_label)
+        yield msg, _status_html(
+            ["ok", "wait", "wait", "wait", "wait"],
+            {"elapsed_s": _elapsed()}, steps=steps
+        ), _table_html()
+        return
+
+    if not NGC_API_KEY:
+        msg = "[NIM] Skipped — NGC_API_KEY not set (export NGC_API_KEY=nvapi-...)"
+        _log_run(model_id, total_s=_elapsed(), status="skipped-no-key", display_label=display_label)
+        yield msg, _status_html(
+            ["ok", "wait", "wait", "wait", "wait"],
+            {"elapsed_s": _elapsed()}, steps=steps
+        ), _table_html()
+        return
+
+    # Step 2: validate key (lightweight)
+    print(f"[nim] NGC_API_KEY present ({len(NGC_API_KEY)} chars)", flush=True)
+    yield "", _status_html(["ok", "ok", "run", "wait", "wait"],
+                           {"elapsed_s": _elapsed()}, steps=steps), gr.update()
+
+    # Step 3: prepare media content
+    if is_image:
+        try:
+            from PIL import Image as _pil_img
+            _img = _pil_img.open(video_path).convert("RGB")
+            _buf = io.BytesIO()
+            _img.save(_buf, format="JPEG", quality=85)
+            _img_b64 = base64.b64encode(_buf.getvalue()).decode()
+        except Exception as _img_err:
+            msg = f"[NIM ERROR] Could not read image: {_img_err}"
+            _log_run(model_id, total_s=_elapsed(), status="image-error", display_label=display_label)
+            yield msg, _status_html(["ok", "ok", "wait", "wait", "wait"],
+                               {"elapsed_s": _elapsed()}, steps=steps), _table_html()
+            return
+        content = [
+            {"type": "text", "text": prompt},
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{_img_b64}"}},
+        ]
+        print(f"[nim/image] base64 image prepared", flush=True)
+    else:
+        print(f"[nim] Extracting frames fps={fps} max={8}", flush=True)
+        frames_b64 = _extract_frames_b64(video_path, fps=fps, max_frames=8)
+        if not frames_b64:
+            msg = "[NIM ERROR] Could not extract frames from video (PyAV missing or video unreadable)"
+            _log_run(model_id, total_s=_elapsed(), status="frame-error", display_label=display_label)
+            yield msg, _status_html(["ok", "ok", "wait", "wait", "wait"],
+                               {"elapsed_s": _elapsed()}, steps=steps), _table_html()
+            return
+        print(f"[nim] {len(frames_b64)} frames extracted", flush=True)
+        content = [{"type": "text", "text": f"[Video — {len(frames_b64)} frames at {fps}fps]\n{prompt}"}]
+        for fb64 in frames_b64:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{fb64}"},
+            })
+
+    # Step 4: send to NVCF
+
+    yield "", _status_html(["ok", "ok", "ok", "run", "wait"],
+                            {"model_id": model_id, "elapsed_s": _elapsed()}, steps=steps), gr.update()
+
+    t_start = time.time()
+    try:
+        resp = _requests.post(
+            NIM_ENDPOINT,
+            headers={"Authorization": f"Bearer {NGC_API_KEY}", "Content-Type": "application/json"},
+            json={
+                "model": NIM_MODEL_API,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user",   "content": content},
+                ],
+                "max_tokens": max_tokens,
+                "stream": True,
+            },
+            stream=True,
+            timeout=120,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        err = f"[NIM ERROR] {e}"
+        print(err, flush=True)
+        _log_run(model_id, total_s=_elapsed(), status="api-error")
+        yield err, _status_html(["ok", "ok", "ok", "wait", "wait"],
+                                  {"model_id": model_id, "elapsed_s": _elapsed()}, steps=steps), _table_html()
+        return
+
+    # Step 5: stream
+    parts  = []
+    ttft_s = None
+    tokens_decoded = 0
+
+    for line in resp.iter_lines():
+        if not line:
+            continue
+        if isinstance(line, bytes):
+            line = line.decode("utf-8")
+        if not line.startswith("data: "):
+            continue
+        data = line[6:]
+        if data == "[DONE]":
+            break
+        try:
+            delta = json.loads(data)["choices"][0]["delta"].get("content", "")
+        except (json.JSONDecodeError, KeyError, IndexError):
+            continue
+        if delta:
+            if ttft_s is None:
+                ttft_s = time.time() - t_start
+            parts.append(delta)
+            tokens_decoded += 1
+            cur_metrics = {
+                "model_id": model_id,
+                "tokens_out": tokens_decoded,
+                "ttft_s": ttft_s,
+                "elapsed_s": _elapsed(),
+            }
+            yield "".join(parts), _status_html(
+                ["ok", "ok", "ok", "ok", "run"], cur_metrics, steps=steps
+            ), gr.update()
+
+    infer_time = time.time() - t_start
+    response   = "".join(parts)
+    total_s    = _elapsed()
+
+    result = {
+        "model": model_id, "prompt": prompt, "response": response,
+        "infer_time_s": round(infer_time, 1),
+        "ttft_s": round(ttft_s, 2) if ttft_s else None,
+        "tokens_out": tokens_decoded,
+        "frames_sent": len(frames_b64), "fps": fps, "status": "success",
+    }
+    try:
+        with open(OUT_FILE, "w") as f:
+            json.dump(result, f, indent=2)
+    except Exception:
+        pass
+
+    print(f"[nim done] {infer_time:.1f}s · {tokens_decoded} tok out", flush=True)
+    _log_run(model_id, ttft_s=ttft_s, infer_s=infer_time,
+             tokens_out=tokens_decoded, total_s=total_s, status="ok", display_label=display_label)
+    yield response, _status_html(
+        ["ok", "ok", "ok", "ok", "ok"],
+        {"model_id": model_id, "tokens_out": tokens_decoded,
+         "ttft_s": ttft_s, "infer_s": infer_time, "elapsed_s": total_s},
+        steps=steps,
+    ), _table_html()
+
+
+# ── HF inference ───────────────────────────────────────────────────────────────
+def run_inference(video_path, user_prompt, system_prompt, fps, max_pixels, max_new_tokens, model_id, disable_autocap=False, display_label=None, is_image=False, temperature=0.0, top_p=1.0, rep_penalty=1.0):
+    """Generator: (response_text, status_html, table_html). Routes to NIM or HF path."""
+    if video_path is None:
+        yield "Upload a video or image first.", _status_html(["wait"] * 5), gr.update()
+        return
+    if not user_prompt.strip():
+        user_prompt = DEFAULT_PROMPT
+
+    fps            = int(fps)
+    max_pixels     = int(max_pixels)
+    max_new_tokens = int(max_new_tokens)
+    t_run_start    = time.time()
+
+    def _elapsed():
+        return time.time() - t_run_start
+
+    # Step 1: resolve checkpoint
+    yield "", _status_html(["run", "wait", "wait", "wait", "wait"],
+                           {"elapsed_s": _elapsed()}), gr.update()
+
+    # NIM local Docker is served by `_run_vllm_inference` via the OpenAI-compatible
+    # client at VLLM_BASE_URL. The NIM container enforces a 5-image-per-prompt cap;
+    # frame clamping is applied below at extraction time when INFERENCE_BACKEND=nim_local.
+
+    if _is_nim(model_id):
+        yield from _run_nim_inference(
+            video_path, user_prompt, system_prompt, fps, max_new_tokens, model_id,
+            t_run_start=t_run_start,
+            display_label=display_label,
+            is_image=is_image,
+        )
+        return
+
+    if _is_vllm(model_id):
+        # Use the server's actual served model name (from --served-model-name),
+        # not the local checkpoint path which the API doesn't recognise.
+        _effective_mid = _SERVER_MODEL_ID or model_id
+        # When serving a different model than requested, note it in the table.
+        _req_short = model_id.split("/")[-1] if "/" in model_id else model_id
+        _srv_short = _effective_mid.split("/")[-1] if "/" in _effective_mid else _effective_mid
+        _extra_note = f"vLLM serves {_srv_short}" if _srv_short != _req_short else None
+        yield from _run_vllm_inference(
+            video_path, user_prompt, system_prompt, fps, max_new_tokens, _effective_mid,
+            t_run_start=t_run_start,
+            display_label=display_label,
+            extra_note=_extra_note,
+            is_image=is_image,
+            temperature=temperature,
+            top_p=top_p,
+            rep_penalty=rep_penalty,
+        )
+        return
+
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else "CPU"
+    print(f"[infer] model={model_id} gpu={gpu_name}", flush=True)
+
+    # Step 2: load model
+    yield "", _status_html(["ok", "run", "wait", "wait", "wait"],
+                           {"model_id": model_id, "elapsed_s": _elapsed()}), gr.update()
+    try:
+        model, processor, load_t = _load(model_id)
+    except Exception as e:
+        err = f"[ERROR] Failed to load {model_id}: {e}"
+        print(err, flush=True)
+        _log_run(model_id, total_s=_elapsed(), status="load-error",
+                 notes=f"Load failed: {str(e)[:80]}", display_label=display_label)
+        yield err, _status_html(["ok", "wait", "wait", "wait", "wait"],
+                                {"model_id": model_id, "elapsed_s": _elapsed(),
+                                 "backend": "HF"}), _table_html()
+        return
+
+    _upcast = _loaded.get("upcast_warning")
+
+    # Step 3: preprocess video
+    yield "", _status_html(
+        ["ok", "ok", "run", "wait", "wait"],
+        {"model_id": model_id, "load_s": load_t, "elapsed_s": _elapsed(),
+         "upcast_warning": _upcast, "backend": "HF"},
+    ), gr.update()
+
+    if is_image:
+        # Image auto-cap: same _auto_cap math as video with n_frames=1, then
+        # bound at IMAGE_AUTO_CAP_MAX. _EMPIRICAL_VPF is calibrated for video
+        # token math; for Cosmos3 single-image inputs the per-pixel token rate
+        # is ~3-5x higher, so unbounded auto-cap snaps to the 2M-px tier and
+        # still produces 5+ min prefills on HF backend.
+        if not disable_autocap:
+            capped_px, est_s = _auto_cap(1, max_pixels)
+            capped_px = min(capped_px, IMAGE_AUTO_CAP_MAX)
+            if capped_px < max_pixels:
+                print(f"[auto-cap image] {max_pixels:,} → {capped_px:,} px (~{est_s:.0f}s est, hard cap={IMAGE_AUTO_CAP_MAX:,})", flush=True)
+                max_pixels = capped_px
+        conversation = [
+            {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+            {"role": "user", "content": [
+                {"type": "image", "image": video_path, "max_pixels": max_pixels},
+                {"type": "text", "text": user_prompt},
+            ]},
+        ]
+    else:
+        m = get_video_meta(video_path)
+        if m.duration_s > 0 and not disable_autocap:
+            n_frames = max(1, int(m.duration_s * fps))
+            capped_px, est_s = _auto_cap(n_frames, max_pixels)
+            if capped_px < max_pixels:
+                print(f"[auto-cap] {max_pixels:,} → {capped_px:,} px (~{est_s:.0f}s est)", flush=True)
+                max_pixels = capped_px
+        # BUG-FPS-NFRAMES: newer qwen_vl_utils raises "Only accept either fps or nframes"
+        # if both keys are present in the video dict. Pick whichever yields fewer frames:
+        # use nframes (uniform subsample to _MAX_HF_FRAMES) when fps would exceed the cap,
+        # otherwise pass fps and let the backend sample naturally.
+        n_at_fps = max(1, int((m.duration_s if m.duration_s > 0 else 1) * fps))
+        video_part = {"type": "video", "video": video_path, "max_pixels": max_pixels}
+        if n_at_fps > _MAX_HF_FRAMES:
+            video_part["nframes"] = _MAX_HF_FRAMES
+        else:
+            video_part["fps"] = fps
+        conversation = [
+            {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+            {"role": "user", "content": [
+                video_part,
+                {"type": "text", "text": user_prompt},
+            ]},
+        ]
+
+    t1 = time.time()
+    text_prompt = processor.apply_chat_template(
+        conversation, tokenize=False, add_generation_prompt=True
+    )
+    image_inputs, video_inputs = qwen_vl_utils.process_vision_info(conversation)
+    inputs = processor(
+        text=[text_prompt],
+        images=image_inputs,
+        videos=video_inputs,
+        return_tensors="pt",
+        padding=True,
+    )
+    inputs = {k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+    tokens_in = inputs["input_ids"].shape[1]
+
+    # Step 4: prefill
+    print(f"[infer] Prefilling {tokens_in:,} tokens ...", flush=True)
+    yield "", _status_html(
+        ["ok", "ok", "ok", "run", "wait"],
+        {"model_id": model_id, "load_s": load_t, "tokens_in": tokens_in,
+         "elapsed_s": _elapsed(), "upcast_warning": _upcast, "backend": "HF"},
+    ), gr.update()
+
+    streamer = TextIteratorStreamer(
+        processor.tokenizer,
+        skip_prompt=True,
+        skip_special_tokens=True,
+        timeout=180.0,
+    )
+    gen_thread = threading.Thread(
+        target=model.generate,
+        kwargs={
+            **inputs,
+            "max_new_tokens":     max_new_tokens,
+            "do_sample":          False,
+            "repetition_penalty": 1.05,
+            "streamer":           streamer,
+        },
+        daemon=True,
+    )
+    gen_thread.start()
+
+    # Step 5: generate
+    parts          = []
+    ttft_s         = None
+    tokens_decoded = 0
+    t_gen          = time.time()
+
+    for chunk in streamer:
+        if chunk:
+            if ttft_s is None:
+                ttft_s = time.time() - t_gen
+            parts.append(chunk)
+            tokens_decoded += 1  # TextIteratorStreamer emits ~1 token per chunk
+            cur_metrics = {
+                "model_id":       model_id,
+                "load_s":         load_t,
+                "tokens_in":      tokens_in,
+                "tokens_out":     tokens_decoded,
+                "ttft_s":         ttft_s,
+                "elapsed_s":      _elapsed(),
+                "upcast_warning": _upcast,
+                "backend":        "HF",
+            }
+            yield "".join(parts), _status_html(
+                ["ok", "ok", "ok", "ok", "run"], cur_metrics
+            ), gr.update()
+
+    gen_thread.join(timeout=10)
+    infer_time = time.time() - t1
+    response   = "".join(parts)
+    tokens_out = len(processor.tokenizer.encode(response, add_special_tokens=False))
+
+    result = {
+        "model":        model_id,
+        "prompt":       user_prompt,
+        "response":     response,
+        "load_time_s":  round(load_t, 1),
+        "infer_time_s": round(infer_time, 1),
+        "ttft_s":       round(ttft_s, 2) if ttft_s else None,
+        "tokens_in":    tokens_in,
+        "tokens_out":   tokens_out,
+        "fps":          fps,
+        "status":       "success",
+    }
+    try:
+        with open(OUT_FILE, "w") as f:
+            json.dump(result, f, indent=2)
+    except Exception:
+        pass
+
+    total_s = _elapsed()
+    print(f"[done] {infer_time:.1f}s · {tokens_out} tok · ttft={ttft_s:.2f}s", flush=True)
+    _log_run(model_id, load_s=load_t, ttft_s=ttft_s, infer_s=infer_time,
+             tokens_out=tokens_out, total_s=total_s, status="ok",
+             notes=_upcast or "", display_label=display_label)
+    yield response, _status_html(
+        ["ok", "ok", "ok", "ok", "ok"],
+        {"model_id": model_id, "load_s": load_t,
+         "tokens_in": tokens_in, "tokens_out": tokens_out,
+         "ttft_s": ttft_s, "infer_s": infer_time, "elapsed_s": total_s,
+         "upcast_warning": _upcast, "backend": "HF"},
+    ), _table_html()
+
+
+# ── Sequential variant runner ──────────────────────────────────────────────────
+def run_all_variants(video_path, user_prompt, system_prompt, fps, max_pixels, max_new_tokens, disable_autocap=False, reload_vllm=False):
+    """Generator: (combined_text, status_html, table_html). Runs all MODEL_SIZE variants."""
+    if video_path is None:
+        yield "Upload a video first.", _status_html(["wait"] * 5), gr.update()
+        return
+
+    # Build full variant list including extended (e.g. 32B after 8B BF16)
+    _hf_variants = [
+        (label, dirname, hf_id, _resolve(dirname, hf_id))
+        for label, dirname, hf_id, _ in _cfg["variants"]
+    ]
+    _extended = [
+        (label, dirname, hf_id, _resolve(dirname, hf_id))
+        for label, dirname, hf_id, _ in _cfg.get("extended_variants", [])
+    ]
+    _nim_entry = [(f"NIM-{MODEL_SIZE}", None, _nim_api_id, f"nim://{_nim_api_id}")]
+    # Order: all but last HF, then NIM, then last HF (BF16 = most accurate), then 32B
+    _variants_full = _hf_variants[:-1] + _nim_entry + _hf_variants[-1:] + _extended
+
+    _do_reload = reload_vllm and INFERENCE_BACKEND == "vllm"
+
+    if INFERENCE_BACKEND in ("vllm", "nim_local"):
+        _be_hdr = "NIM (local Docker)" if INFERENCE_BACKEND == "nim_local" else "vLLM"
+        if _do_reload:
+            combined = (f"[{_be_hdr} mode — real benchmarks: reloading vLLM per variant]\n"
+                        f"Each variant restarts the vLLM server. Gradio stays live. "
+                        f"Allow ~60–90s between variants for model loading.\n\n")
+        else:
+            combined = (f"[{_be_hdr} mode — backend: {VLLM_BASE_URL}]\n"
+                        f"Serves one model at a time. Each variant uses the loaded model; "
+                        f"non-matching variants are noted in the table.\n\n")
+    else:
+        combined = ""
+
+    all_results = {}
+    bench_file  = "/tmp/byo_video_benchmark.json"
+
+    for var_label, var_dirname, var_hf_id, var_model_id in _variants_full:
+        header_line = f"\n{'='*52}\n▶  {var_label}\n{'='*52}\n"
+        combined += header_line
+
+        # Hot-swap vLLM if requested and this is a non-NIM HF variant
+        if _do_reload and not _is_nim(var_model_id) and var_hf_id:
+            if not os.path.exists(var_model_id):
+                # Model not on disk — skip swap, preserve running server
+                combined += (
+                    f"[Skipping vLLM reload for {var_label} — model not on disk. "
+                    f"Running server will be used.]\n"
+                )
+                yield combined, _status_html(
+                    ["run", "wait", "wait", "wait", "wait"],
+                    {"model_id": var_model_id, "backend": "VLLM"},
+                    steps=VLLM_STEPS,
+                ), gr.update()
+            else:
+                launched = _launch_vllm_swap(var_model_id, var_hf_id)
+                if not launched:
+                    err = f"[vLLM binary not found — skipping {var_label}]\n"
+                    combined += err
+                    _log_run(var_model_id, total_s=0, status="reload-error", display_label=var_label)
+                    yield combined, _status_html(["ok", "wait", "wait", "wait", "wait"],
+                                                 {}, steps=VLLM_STEPS), _table_html()
+                    continue
+                # Inline polling loop — yields progress every 5 s so Gradio stays responsive
+                _swap_start = time.time()
+                actual_id   = None
+                while True:
+                    _elapsed = time.time() - _swap_start
+                    if _elapsed > _VLLM_SWAP_TIMEOUT:
+                        break
+                    _remain_lo = max(0, 60 - _elapsed)
+                    _remain_hi = max(0, 90 - _elapsed)
+                    _prog = (
+                        f"[Loading {var_label} into vLLM — "
+                        f"{_elapsed:.0f}s elapsed, "
+                        f"~{_remain_lo:.0f}–{_remain_hi:.0f}s remaining…]\n"
+                    )
+                    yield combined + _prog, _status_html(
+                        ["run", "wait", "wait", "wait", "wait"],
+                        {"model_id": var_model_id, "backend": "VLLM"},
+                        steps=VLLM_STEPS,
+                    ), gr.update()
+                    time.sleep(5)
+                    try:
+                        import urllib.request as _urlreq2
+                        with _urlreq2.urlopen(f"{VLLM_BASE_URL}/models", timeout=3) as _r2:
+                            _mdata = json.loads(_r2.read())
+                        _ids = [m["id"] for m in _mdata.get("data", [])]
+                        if _ids:
+                            actual_id = _ids[0]
+                            break
+                    except Exception:
+                        pass
+                if actual_id is None:
+                    err = f"[vLLM reload timed out for {var_label}. Skipping.]\n"
+                    combined += err
+                    _log_run(var_model_id, total_s=0, status="reload-timeout", display_label=var_label)
+                    yield combined, _status_html(["ok", "wait", "wait", "wait", "wait"],
+                                                 {}, steps=VLLM_STEPS), _table_html()
+                    continue
+                global _SERVER_MODEL_ID
+                _SERVER_MODEL_ID = actual_id
+                _swap_dur = time.time() - _swap_start
+                combined += f"[vLLM ready — serving {actual_id} ({_swap_dur:.0f}s)]\n"
+
+        yield combined, _status_html(
+            ["run", "wait", "wait", "wait", "wait"],
+            {"model_id": var_model_id},
+        ), gr.update()
+
+        last_text   = ""
+        last_table  = gr.update()
+
+        for text, status, tbl in run_inference(
+            video_path, user_prompt, system_prompt,
+            fps, max_pixels, max_new_tokens, var_model_id,
+            disable_autocap=disable_autocap,
+            display_label=var_label,
+        ):
+            last_text  = text
+            last_table = tbl
+            yield combined + text, status, tbl
+
+        if not _is_nim(var_model_id) and not _is_vllm(var_model_id):
+            _unload()
+
+        all_results[var_label] = {"model": var_model_id, "response": last_text}
+        combined += last_text + "\n"
+
+    # Save comparison JSON
+    try:
+        with open(bench_file, "w") as f:
+            json.dump(all_results, f, indent=2)
+        combined += f"\n*All results → {bench_file}*"
+    except Exception:
+        pass
+
+    yield combined, _status_html(["ok", "ok", "ok", "ok", "ok"]), _table_html()
+
+
+# ── Startup: pre-load default model if available locally ───────────────────────
+# PRELOAD-001: skip HF preload in vLLM mode — model is served by vLLM process, not Python.
+# Loading here wastes ~9 GB VRAM (weights loaded twice) and risks OOM on 80 GB GPUs.
+# Set SKIP_HF_PRELOAD=1 to force-skip even in HF mode (useful when VRAM is tight).
+_SKIP_PRELOAD = (
+    INFERENCE_BACKEND == "vllm"
+    or os.environ.get("SKIP_HF_PRELOAD", "").lower() in ("1", "true", "yes")
+)
+_preloaded_ok = False
+if os.path.exists(MODEL_DIR) and not _SKIP_PRELOAD:
+    print(f"[demo] Pre-loading {MODEL_DIR} ...", flush=True)
+    try:
+        _load(MODEL_DIR)
+        _preloaded_ok = True
+    except Exception as e:
+        print(f"[demo] Pre-load failed ({e}) — model loads on first inference", flush=True)
+elif _SKIP_PRELOAD and INFERENCE_BACKEND == "vllm":
+    print(f"[demo] vLLM mode — skipping HF preload (PRELOAD-001 fix)", flush=True)
+else:
+    print(f"[demo] MODEL_DIR not found — model loads on first inference", flush=True)
+
+gpu_name  = torch.cuda.get_device_name(0) if torch.cuda.is_available() else "CPU"
+free_vram = get_free_vram_mib()
+load_time = _loaded["load_time"]
+
+_header_model = _loaded["model_id"] or MODEL_NAME
+_load_note    = f"Load: {load_time:.1f}s" if _preloaded_ok else "Load: on demand"
+
+
+# ── vLLM hot-swap (restart server without killing Gradio) ─────────────────────
+_VLLM_PROC = None  # track last vLLM subprocess so we can kill it cleanly
+
+_VLLM_SWAP_TIMEOUT = 150  # seconds to wait for vLLM to become ready
+
+def _launch_vllm_swap(local_path, served_name, gpu_util="0.85", max_model_len="32768"):
+    """
+    Kill the current vLLM server and launch a new one for `local_path`.
+    Returns immediately — caller is responsible for polling /v1/models.
+    Returns True on successful launch, False if the vLLM binary is not found.
+    """
+    global _VLLM_PROC
+    import subprocess as _sp
+
+    vllm_bin = os.path.join(HOME, "cosmos-reason2/.venv/bin/vllm")
+    if not os.path.exists(vllm_bin):
+        print(f"[vllm-swap] vLLM binary not found at {vllm_bin}", flush=True)
+        return False
+
+    _sp.run(["pkill", "-f", "vllm serve"], capture_output=True)
+    if _VLLM_PROC is not None:
+        try:
+            _VLLM_PROC.terminate()
+        except Exception:
+            pass
+        _VLLM_PROC = None
+    time.sleep(4)  # allow GPU memory to release
+
+    # Per-model extra flags (e.g. --allowed-local-media-path for Nemotron/Qwen).
+    _model_cfg   = MODEL_CONFIGS.get(MODEL_SIZE, {})
+    extra_flags  = _model_cfg.get("vllm_swap_flags", [])
+    extra_env    = {**os.environ, **_model_cfg.get("vllm_swap_env", {})}
+
+    print(f"[vllm-swap] Launching {served_name} (path={local_path}) flags={extra_flags}", flush=True)
+    _VLLM_PROC = _sp.Popen(
+        [
+            vllm_bin, "serve", local_path,
+            "--served-model-name", served_name,
+            "--port", "8000",
+            "--dtype", "auto",
+            "--trust-remote-code",
+            "--max-model-len", max_model_len,
+            "--gpu-memory-utilization", gpu_util,
+        ] + extra_flags,
+        env=extra_env,
+        stdout=_sp.DEVNULL,
+        stderr=_sp.DEVNULL,
+    )
+    return True
+
+
+def _swap_banner_html(model_short, state, elapsed=0, remain_lo=60, remain_hi=90):
+    if state == "loading":
+        return (
+            f'<div style="background:#7c4d00;border:1px solid #f59e0b;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#fef3c7;margin:4px 0">'
+            f'⚠ Restarting vLLM for <b>{model_short}</b>… '
+            f'{elapsed:.0f}s elapsed, ~{remain_lo:.0f}–{remain_hi:.0f}s remaining. '
+            f'Gradio stays live.</div>'
+        )
+    if state == "ready":
+        return (
+            f'<div style="background:#14532d;border:1px solid #22c55e;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#dcfce7;margin:4px 0">'
+            f'✅ vLLM now serving <b>{model_short}</b> ({elapsed:.0f}s)</div>'
+        )
+    if state == "error":
+        return (
+            f'<div style="background:#450a0a;border:1px solid #f87171;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#fee2e2;margin:4px 0">'
+            f'❌ vLLM reload failed for <b>{model_short}</b> (timed out after {elapsed:.0f}s). '
+            f'Check server logs.</div>'
+        )
+    if state == "nodisk":
+        return (
+            f'<div style="background:#1c1917;border:1px solid #a8a29e;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#d6d3d1;margin:4px 0">'
+            f'⚠ <b>{model_short}</b> not on disk — use HF token to download. '
+            f'Running server unchanged.</div>'
+        )
+    return ""
+
+
+def _vllm_swap_yields(label, local_path, hf_id):
+    """Shared generator for the vLLM swap+poll loop.
+    Yields (banner_html, btn_update, fps_update, maxpx_update)."""
+    _fps, _mpx, _mtok = _ckpt_slider_defaults(label)
+    _no_change = gr.update()
+    yield _swap_banner_html(label, "loading", 0, 60, 90), gr.update(visible=False), _no_change, _no_change
+    launched = _launch_vllm_swap(local_path, hf_id)
+    if not launched:
+        yield _swap_banner_html(label, "error", 0), gr.update(visible=True), _no_change, _no_change
+        return
+    _swap_start = time.time()
+    actual_id = None
+    while True:
+        _elapsed = time.time() - _swap_start
+        if _elapsed > _VLLM_SWAP_TIMEOUT:
+            break
+        _remain_lo = max(0, 60 - _elapsed)
+        _remain_hi = max(0, 90 - _elapsed)
+        yield _swap_banner_html(label, "loading", _elapsed, _remain_lo, _remain_hi), gr.update(visible=False), _no_change, _no_change
+        time.sleep(5)
+        try:
+            import urllib.request as _urlreq3
+            with _urlreq3.urlopen(f"{VLLM_BASE_URL}/models", timeout=3) as _r3:
+                _mdata3 = json.loads(_r3.read())
+            _ids3 = [m["id"] for m in _mdata3.get("data", [])]
+            if _ids3:
+                actual_id = _ids3[0]
+                break
+        except Exception:
+            pass
+    _elapsed_final = time.time() - _swap_start
+    if actual_id is None:
+        yield _swap_banner_html(label, "error", _elapsed_final), gr.update(visible=True), _no_change, _no_change
+        return
+    global _SERVER_MODEL_ID
+    _SERVER_MODEL_ID = actual_id
+    yield _swap_banner_html(label, "ready", _elapsed_final), gr.update(visible=False), \
+          gr.update(value=_fps), gr.update(value=_mpx)
+
+
+def _on_checkpoint_change(label):
+    """Reload vLLM when the user selects a new checkpoint (vLLM mode only).
+    Yields (banner_html, download_btn_update, fps_update, maxpx_update)."""
+    _no_change = gr.update()
+    if INFERENCE_BACKEND != "vllm":
+        yield "", gr.update(visible=False), _no_change, _no_change
+        return
+    meta = _VLLM_DD_META.get(label)
+    if meta is None:
+        yield "", gr.update(visible=False), _no_change, _no_change
+        return
+    local_path, hf_id = meta
+    _fps, _mpx, _mtok = _ckpt_slider_defaults(label)
+    if not os.path.exists(local_path):
+        yield _swap_banner_html(label, "nodisk"), gr.update(visible=True), \
+              gr.update(value=_fps), gr.update(value=_mpx)
+        return
+    yield from _vllm_swap_yields(label, local_path, hf_id)
+
+
+def _on_download_and_load(label):
+    """Download model from HF Hub then load it into vLLM.
+    Yields (banner_html, download_btn_update, fps_update, maxpx_update)."""
+    _no_change = gr.update()
+    meta = _VLLM_DD_META.get(label)
+    if meta is None:
+        yield _swap_banner_html(label, "nodisk"), gr.update(visible=True), _no_change, _no_change
+        return
+    local_path, hf_id = meta
+    if os.path.exists(local_path):
+        yield from _vllm_swap_yields(label, local_path, hf_id)
+        return
+
+    import threading as _thr
+
+    _dl_state = {"done": False, "error": None}
+
+    def _dl():
+        try:
+            from huggingface_hub import snapshot_download as _snap
+            _snap(
+                repo_id=hf_id,
+                local_dir=local_path,
+                token=HF_TOKEN or None,
+                local_dir_use_symlinks=False,
+            )
+            # Clean HF cache blob for this model — files are now in local_dir
+            try:
+                import shutil as _sh
+                _cache_repo = os.path.join(
+                    _HF_CACHE_DIR, "models--" + hf_id.replace("/", "--")
+                )
+                if os.path.exists(_cache_repo):
+                    _sh.rmtree(_cache_repo, ignore_errors=True)
+            except Exception:
+                pass
+            _dl_state["done"] = True
+        except Exception as e:
+            _dl_state["error"] = str(e)
+            _dl_state["done"] = True
+
+    _thr.Thread(target=_dl, daemon=True).start()
+    _dl_start = time.time()
+
+    while not _dl_state["done"]:
+        _elapsed = time.time() - _dl_start
+        try:
+            import subprocess as _sp2
+            _sz = _sp2.check_output(
+                ["du", "-sh", local_path], stderr=_sp2.DEVNULL, timeout=3
+            ).decode().split()[0]
+            _sz_note = f" · {_sz} downloaded"
+        except Exception:
+            _sz_note = ""
+        yield (
+            f'<div style="background:#1e3a5f;border:1px solid #60a5fa;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#dbeafe;margin:4px 0">'
+            f'⬇ Downloading <b>{label}</b> from HF Hub{_sz_note} · '
+            f'{_elapsed:.0f}s elapsed · large models take 10–30 min</div>'
+        ), gr.update(visible=False), gr.update(), gr.update()
+        time.sleep(10)
+
+    if _dl_state["error"]:
+        yield (
+            f'<div style="background:#450a0a;border:1px solid #f87171;border-radius:6px;'
+            f'padding:10px 14px;font-size:13px;color:#fee2e2;margin:4px 0">'
+            f'❌ Download failed for <b>{label}</b>: {_dl_state["error"][:160]}</div>'
+        ), gr.update(visible=True), gr.update(), gr.update()
+        return
+
+    yield from _vllm_swap_yields(label, local_path, hf_id)
+
+
+# ── HF auth helpers ───────────────────────────────────────────────────────────
+def _hf_apply_token(token_val):
+    """Apply an HF token to the running process and HF token cache."""
+    global HF_TOKEN
+    token_val = token_val.strip()
+    if not token_val:
+        return '<div style="color:#fbbf24;font-size:12px">Enter a token first.</div>'
+    try:
+        from huggingface_hub import login as _hf_login, whoami as _hf_whoami
+        _hf_login(token=token_val, add_to_git_credential=False)
+        HF_TOKEN = token_val
+        info = _hf_whoami(token=token_val)
+        name = info.get("name", "unknown")
+        return (
+            f'<div style="color:#86efac;font-size:12px">'
+            f'✅ Authenticated as <b>{name}</b>. Gated models now accessible in this session.</div>'
+        )
+    except Exception as e:
+        return f'<div style="color:#f87171;font-size:12px">❌ Auth failed: {e}</div>'
+
+
+def _hf_check_status():
+    """Return current HF auth status."""
+    try:
+        from huggingface_hub import whoami as _hf_whoami
+        info = _hf_whoami()
+        return (
+            f'<div style="color:#86efac;font-size:12px">'
+            f'✅ Authenticated as <b>{info.get("name","?")}</b></div>'
+        )
+    except Exception:
+        return '<div style="color:#fbbf24;font-size:12px">⚠ Not authenticated — gated models require a token.</div>'
+
+
+# ── Disk / storage helpers ────────────────────────────────────────────────────
+_HF_CACHE_DIR = os.path.join(HOME, ".cache", "huggingface", "hub")
+
+def _disk_status_html():
+    import subprocess as _sp
+    try:
+        df_out = _sp.check_output(["df", "-h", "/"], timeout=5).decode().strip().split("\n")
+        parts = df_out[1].split()
+        total, used, avail, pct = parts[1], parts[2], parts[3], parts[4]
+        bar_color = "#f87171" if int(pct.rstrip("%")) >= 90 else "#fbbf24" if int(pct.rstrip("%")) >= 75 else "#86efac"
+
+        rows = ""
+        if os.path.exists(_MODELS_BASE):
+            for d in sorted(os.listdir(_MODELS_BASE)):
+                try:
+                    sz = _sp.check_output(["du", "-sh", os.path.join(_MODELS_BASE, d)], stderr=_sp.DEVNULL, timeout=8).decode().split()[0]
+                    rows += (
+                        f'<tr><td style="padding:2px 8px;font-size:12px;color:#d1d5db">'
+                        f'models/{d}</td>'
+                        f'<td style="padding:2px 8px;font-size:12px;text-align:right;color:#d1d5db">{sz}</td></tr>'
+                    )
+                except Exception:
+                    pass
+
+        hf_sz = ""
+        if os.path.exists(_HF_CACHE_DIR):
+            try:
+                hf_sz = _sp.check_output(["du", "-sh", _HF_CACHE_DIR], stderr=_sp.DEVNULL, timeout=10).decode().split()[0]
+                rows += (
+                    f'<tr style="border-top:1px solid #374151">'
+                    f'<td style="padding:2px 8px;font-size:12px;color:#fbbf24">HF download cache</td>'
+                    f'<td style="padding:2px 8px;font-size:12px;text-align:right;color:#fbbf24">{hf_sz} ← safe to clean</td></tr>'
+                )
+            except Exception:
+                pass
+
+        table = (
+            f'<table style="width:100%;border-collapse:collapse;margin-top:6px">'
+            f'<tr style="border-bottom:1px solid #374151">'
+            f'<th style="text-align:left;font-size:11px;color:#6b7280;padding:2px 8px">Directory</th>'
+            f'<th style="text-align:right;font-size:11px;color:#6b7280;padding:2px 8px">Size</th></tr>'
+            f'{rows}</table>'
+        ) if rows else ""
+
+        return (
+            f'<div style="font-size:13px;padding:4px 0">'
+            f'<b>Disk:</b> <span style="color:{bar_color}">{used} used / {total} ({pct})</span>'
+            f' &nbsp;·&nbsp; <span style="color:#86efac">{avail} free</span>'
+            f'</div>{table}'
+        )
+    except Exception as e:
+        return f'<div style="color:#f87171;font-size:12px">Could not read disk info: {e}</div>'
+
+
+def _clean_hf_cache():
+    if not os.path.exists(_HF_CACHE_DIR):
+        return _disk_status_html() + '<div style="color:#86efac;font-size:12px;margin-top:4px">HF cache already empty.</div>'
+    import subprocess as _sp, shutil as _sh
+    try:
+        sz = _sp.check_output(["du", "-sh", _HF_CACHE_DIR], stderr=_sp.DEVNULL, timeout=10).decode().split()[0]
+        _sh.rmtree(_HF_CACHE_DIR, ignore_errors=True)
+        msg = f'<div style="color:#86efac;font-size:12px;margin-top:4px">✅ Cleared {sz} from HF download cache.</div>'
+    except Exception as e:
+        msg = f'<div style="color:#f87171;font-size:12px;margin-top:4px">❌ {e}</div>'
+    return _disk_status_html() + msg
+
+
+# ── Gradio UI ─────────────────────────────────────────────────────────────────
+with gr.Blocks(
+    title="Cosmos Reason — BYO Video Demo",
+    css=_REASONING_PANEL_CSS,
+) as demo:
+
+    _variant_labels = " → ".join(lbl for lbl, _, _, _ in _cfg["variants"])
+    if _cfg["nim"]:
+        _variant_labels += f" → NIM-{MODEL_SIZE}"
+    _backend_note = (
+        f"**Backend:** NIM local Docker (`{VLLM_BASE_URL}`)"
+        if INFERENCE_BACKEND == "nim_local"
+        else f"**Backend:** vLLM (`{VLLM_BASE_URL}`)"
+        if INFERENCE_BACKEND == "vllm"
+        else "**Backend:** HF transformers *(quantized models upcast to BF16)*"
+    )
+    gr.Markdown(
+        f"# 🌌 Cosmos Reason — BYO Video Demo ({MODEL_SIZE})\n"
+        f"**{_load_note}** &nbsp;·&nbsp; **GPU:** {gpu_name} &nbsp;·&nbsp; "
+        f"**VRAM free:** {free_vram:,} MiB &nbsp;·&nbsp; {_backend_note}\n\n"
+        f"Upload any MP4 or image (JPG/PNG/WebP) and ask the model a question. "
+        f"Select a checkpoint from the dropdown to load it into vLLM."
+    )
+
+    # ── Input row ───────────────────────────────────────────────────────────
+    with gr.Row():
+        with gr.Column(scale=2):
+            with gr.Tabs():
+                with gr.TabItem("Video"):
+                    video_input = gr.Video(label="Upload Video (MP4)", sources=["upload"], height=250)
+                with gr.TabItem("Image"):
+                    image_input = gr.Image(
+                        label="Upload Image (JPG / PNG / WebP)",
+                        type="filepath",
+                        sources=["upload"],
+                        height=250,
+                    )
+            clip_info = gr.Markdown("*Upload a video or image to see info*")
+
+        with gr.Column(scale=1):
+            demo_picker = gr.Dropdown(
+                label="Demo Prompt",
+                choices=[p[0] for p in DEMO_PROMPTS],
+                value=DEMO_PROMPTS[0][0],
+                info="Quick preset prompts",
+            )
+            with gr.Row():
+                run_btn = gr.Button("▶  Run Inference",    variant="primary",   size="lg")
+                all_btn = gr.Button("⚡  Run All Variants", variant="secondary", size="lg",
+                                    visible=False)
+
+    # ── Advanced Settings ────────────────────────────────────────────────────
+    with gr.Accordion("⚙️  Advanced Settings", open=False):
+
+        # System + User prompt — first thing in Advanced Settings so users
+        # don't have to scroll past backend / NIM panel to edit them.
+        # lines=10, max_lines=10 → fixed-height textboxes with internal
+        # scrollbar for prompts longer than ~10 visual lines (covers the
+        # full <think>-template demo prompts without truncation).
+        with gr.Row():
+            system_box = gr.Textbox(label="System Prompt", value=DEFAULT_SYSTEM,
+                                    lines=10, max_lines=10)
+            user_box   = gr.Textbox(label="User Prompt",   value=DEFAULT_PROMPT,
+                                    lines=10, max_lines=10)
+
+        # ── Backend selector ────────────────────────────────────────────────
+        _active_be = INFERENCE_BACKEND.upper()
+        _vllm_label = f"vLLM ({_VLLM_VERSION})" if _VLLM_VERSION else "vLLM (not installed)"
+        _be_choices = [
+            "HF Transformers" + (" (active)" if _active_be == "HF" else ""),
+            _vllm_label + (" (active)" if _active_be == "VLLM" else ""),
+            "NIM (local Docker)" + (" (active)" if _active_be == "NIM_LOCAL" else ""),
+            "TRT-LLM (not yet supported)",
+        ]
+        _be_map = {c: v for c, v in zip(
+            _be_choices, ["hf", "vllm", "nim_local", "trtllm"]
+        )}
+        _current_be_choice = _be_choices[{"HF": 0, "VLLM": 1, "NIM_LOCAL": 2}.get(_active_be, 0)]
+
+        with gr.Row():
+            backend_radio = gr.Radio(
+                label="Inference Backend",
+                choices=_be_choices,
+                value=_current_be_choice,
+                info=f"Active backend (from env INFERENCE_BACKEND): {_active_be}",
+                interactive=True,
+            )
+            vllm_url_box = gr.Textbox(
+                label="vLLM / NIM Base URL",
+                value=VLLM_BASE_URL,
+                placeholder="http://localhost:8000/v1",
+                info="Used when backend = vLLM or NIM (local Docker)",
+                visible=_active_be in ("VLLM", "NIM_LOCAL"),
+                interactive=True,
+            )
+
+        backend_warn = gr.HTML(value="", visible=False)
+
+        def _on_backend_change(choice):
+            selected = _be_map.get(choice, "hf")
+            active   = INFERENCE_BACKEND
+            if selected == "trtllm":
+                warn_html = (
+                    '<div style="background:#7f1d1d;color:#fca5a5;padding:10px 14px;'
+                    'border-radius:6px;margin:4px 0;font-size:13px">'
+                    '🚫 <b>TRT-LLM</b> is not yet supported in this demo. '
+                    'Use HF Transformers or vLLM backend instead.</div>'
+                )
+                return gr.update(value=warn_html, visible=True), gr.update(visible=False)
+            if selected == "nim_local" and active != "nim_local":
+                _code_pill = ('background:#dbeafe;color:#1e293b;padding:2px 6px;'
+                              'border-radius:4px;font-size:12px')
+                nim_html = (
+                    '<div style="background:#eff6ff;border:1px solid #3b82f6;color:#1e3a8a;'
+                    'padding:10px 14px;border-radius:6px;margin:4px 0;font-size:13px">'
+                    '<b style="color:#1e3a8a">NIM (local Docker)</b> — runs the NIM container on this instance.<br>'
+                    '<b style="color:#1e3a8a">Step 1:</b> Start NIM container (one-time, ~10-20 min download):<br>'
+                    f'<code style="{_code_pill}">bash /tmp/nim_launch.sh &lt;NGC_API_KEY&gt;</code><br>'
+                    '<b style="color:#1e3a8a">Step 2:</b> Restart Gradio with NIM backend:<br>'
+                    f'<code style="{_code_pill}">INFERENCE_BACKEND=nim_local '
+                    'VLLM_BASE_URL=http://localhost:8000/v1 python /tmp/gradio_cr2_byo.py</code><br>'
+                    '<b style="color:#1e3a8a">Model name for checkpoint:</b> use the name from '
+                    f'<code style="{_code_pill}">curl http://localhost:8000/v1/models</code> '
+                    f'or set Custom Checkpoint ID to <code style="{_code_pill}">nvidia/cosmos-reason2-2b</code><br>'
+                    '<b style="color:#1e3a8a">Check NIM status:</b> '
+                    f'<code style="{_code_pill}">docker logs cosmos-nim</code>'
+                    '</div>'
+                )
+                return gr.update(value=nim_html, visible=True), gr.update(visible=True)
+            if selected != active:
+                env_cmd = f"INFERENCE_BACKEND={selected}"
+                if selected == "vllm":
+                    env_cmd += "  VLLM_BASE_URL=http://localhost:8000/v1"
+                _cuda_note = ""
+                if selected == "vllm":
+                    _cuda_note = (
+                        '<br><span style="color:#fca5a5">⚠ vLLM 0.12.0 requires CUDA 12.9+ '
+                        '(driver 575.x+). This instance has CUDA 12.8 (driver 570.x). '
+                        'vLLM server will fail to start unless you use a CUDA 12.9+ instance.</span>'
+                    )
+                warn_html = (
+                    '<div style="background:#78350f;color:#fde68a;padding:10px 14px;'
+                    'border-radius:6px;margin:4px 0;font-size:13px">'
+                    f'⚠ <b>Backend change requires a Gradio restart.</b><br>'
+                    f'Stop Gradio, then relaunch with:<br>'
+                    f'<code style="background:#1c1917;padding:3px 6px;border-radius:4px;'
+                    f'font-size:12px">{env_cmd} python /tmp/gradio_cr2_byo.py</code>'
+                    f'{_cuda_note}'
+                    '</div>'
+                )
+                show_url = selected in ("vllm", "nim_local")
+                return gr.update(value=warn_html, visible=True), gr.update(visible=show_url)
+            return gr.update(value="", visible=False), gr.update(visible=selected in ("vllm", "nim_local"))
+
+        backend_radio.change(
+            fn=_on_backend_change,
+            inputs=[backend_radio],
+            outputs=[backend_warn, vllm_url_box],
+        )
+
+        _is_nim_local = INFERENCE_BACKEND == "nim_local"
+        _ckpt_label = "VLM NIM" if _is_nim_local else "Checkpoint"
+        _ckpt_info = (
+            "VLM NIMs supported on this target. Source: "
+            "docs.nvidia.com/nim/vision-language-models/latest/introduction.html. "
+            "Pick a different NIM and click 'Switch to selected NIM' to swap the "
+            "running container — pull + load takes 5-15 min on first run."
+            if _is_nim_local else
+            "Preset checkpoints — changing this in vLLM mode reloads the server"
+        )
+        with gr.Row():
+            checkpoint_dd = gr.Dropdown(
+                label=_ckpt_label,
+                choices=[p[0] for p in CHECKPOINT_PRESETS],
+                value=_VLLM_DD_DEFAULT,
+                info=_ckpt_info,
+            )
+            custom_ckpt = gr.Textbox(
+                label="Custom Checkpoint ID (overrides dropdown)",
+                placeholder="nvidia/Cosmos-Reason2-8B  or  /path/to/local",
+                value="",
+                visible=not _is_nim_local,
+            )
+
+        _vllm_mode = INFERENCE_BACKEND == "vllm"
+        with gr.Row(visible=_vllm_mode):
+            vllm_swap_banner = gr.HTML(value="", visible=_vllm_mode)
+            download_load_btn = gr.Button(
+                "⬇ Download & Load",
+                variant="primary",
+                visible=False,
+                scale=0,
+                min_width=180,
+            )
+        if not _vllm_mode:
+            vllm_swap_banner = gr.HTML(value="", visible=False)
+            download_load_btn = gr.Button(visible=False)
+
+        # NIM runtime swap — handled out-of-band, not via a Gradio button. The
+        # earlier in-Gradio swap button (commit 4ed5951) attempted to stream
+        # `nim_launch.sh` output through the browser tunnel, but a 5-15 min
+        # docker pull plus 1-3 min vLLM warmup easily blows past Gradio's
+        # streaming heartbeat — the UI appeared to freeze even when the
+        # backend was making progress. Two reliable paths instead:
+        #   (a) Ask the runtime agent (Claude) to swap — it has SSH and can
+        #       run the commands below, watch the logs, and report back.
+        #   (b) Run the commands manually on the host (instructions below).
+        # When the swap finishes, refresh this page — Gradio re-queries
+        # /v1/models on every reload and picks up the new served model id.
+        if _is_nim_local:
+            gr.HTML(
+                "<div style=\"background:#eff6ff;border:1px solid #3b82f6;border-radius:6px;"
+                "padding:12px 14px;margin:8px 0;color:#1e3a8a;font-size:13px;line-height:1.5\">"
+                "<b style=\"color:#1e3a8a\">↻ Switching the running NIM</b><br>"
+                "<span style=\"color:#475569\">"
+                "The dropdown above lists every VLM NIM in the upstream catalog "
+                "(<a href=\"https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html\" "
+                "target=\"_blank\" style=\"color:#1d4ed8\">docs source</a>). To actually swap "
+                "the running container, do one of:"
+                "</span>"
+                "<ol style=\"margin:8px 0 4px 18px;color:#1e3a8a\">"
+                "<li><b>Ask the runtime agent</b> (e.g. Claude) — say <i>“switch the NIM to "
+                "Cosmos Reason2 2B”</i> and it will SSH in, stop the container, run "
+                "<code style=\"font-size:11px;background:#dbeafe;color:#1e293b;padding:1px 4px;"
+                "border-radius:3px\">nim_launch.sh</code>, and confirm "
+                "<code style=\"font-size:11px;background:#dbeafe;color:#1e293b;padding:1px 4px;"
+                "border-radius:3px\">/v1/models</code> is back up.</li>"
+                "<li><b>Run it yourself by SSH</b> (no Claude needed):"
+                "<pre style=\"background:#0f1a2e;border:1px solid #334155;border-radius:4px;"
+                "padding:8px 10px;margin:6px 0;color:#e5e7eb;font-size:11px;overflow-x:auto;"
+                "white-space:pre-wrap\">"
+                "ssh &lt;user@host&gt;\n"
+                "docker rm -f cosmos-nim\n"
+                "MODEL=&lt;short-id&gt; CONTAINER_NAME=cosmos-nim PORT=8000 \\\n"
+                "  bash /tmp/nim_launch.sh &lt;NGC_API_KEY&gt;\n"
+                "# Then reload this Gradio page."
+                "</pre>"
+                "<span style=\"color:#475569;font-size:12px\">"
+                "Short-id values: <code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;"
+                "border-radius:3px\">cosmos-reason2-2b</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "cosmos-reason2-8b</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "cosmos-reason1-7b</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "nemotron-nano-12b-v2-vl</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "llama-3.1-nemotron-nano-vl-8b-v1</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "llama-3.2-11b-vision-instruct</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "llama-3.2-90b-vision-instruct</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "llama-4-maverick-17b-128e-instruct</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "llama-4-scout-17b-16e-instruct</code> · "
+                "<code style=\"background:#dbeafe;color:#1e293b;padding:1px 4px;border-radius:3px\">"
+                "mistral-small-3.2-24b-instruct-2506</code>. "
+                "First-time pulls take 5–15 min; subsequent restarts ~3 min for vLLM warmup."
+                "</span>"
+                "</li></ol>"
+                "</div>",
+                visible=True,
+            )
+
+        with gr.Row():
+            fps_slider = gr.Slider(
+                minimum=1, maximum=8, step=1, value=_UI_DEFAULT_FPS,
+                label="Video sampling rate (fps) — ignored for images",
+                info="Higher = more frames = more tokens = slower. HF mode caps at 32 frames total.",
+            )
+            maxpx_slider = gr.Slider(
+                minimum=64*(32**2), maximum=4096*(32**2), step=64*(32**2),
+                value=DEFAULT_MAX_PIXELS,
+                label="Max pixels per frame",
+            )
+            maxtok_slider = gr.Slider(
+                minimum=64, maximum=2048, step=64, value=DEFAULT_MAX_TOKENS,
+                label="Max output tokens",
+            )
+
+        # NIM-8B-FP8-THINK-EOS: greedy decode (temp=0) on the FP8-quantized
+        # cosmos-reason2-8b NIM emits `<think>` then an EOS-like token, terminating
+        # before any reasoning or final answer is produced. Temperature ≥ ~0.3 breaks
+        # the trap by avoiding the deterministic post-`<think>` EOS path.
+        # build.nvidia.com NIM defaults for cosmos-reason2-8b: T=0.6, top_p=0.3, rep=1.2
+        _NIM_DEFAULTS = (0.6, 0.3, 1.2)
+        _nim_active = INFERENCE_BACKEND == "nim_local"
+        _default_temp = _NIM_DEFAULTS[0] if _nim_active else 0.0
+        _default_top_p = _NIM_DEFAULTS[1] if _nim_active else 1.0
+        _default_rep   = _NIM_DEFAULTS[2] if _nim_active else 1.05
+        nim_defaults_chk = gr.Checkbox(
+            label="Use build.nvidia.com parameter settings",
+            info="One-click apply: Temperature=0.6, Top P=0.3, Repetition Penalty=1.2 (cosmos-reason2-8b NIM defaults).",
+            value=_nim_active,
+        )
+        with gr.Row():
+            temp_slider = gr.Slider(
+                minimum=0.0, maximum=1.0, step=0.05, value=_default_temp,
+                label="Temperature",
+                info=("0 = deterministic. Higher = more creative/varied output."
+                      + (" NIM mode: keep ≥ 0.3 — greedy decode triggers a <think>+EOS"
+                         " bug on the FP8-quantized 8B NIM."
+                         if _nim_active else "")),
+            )
+            top_p_slider = gr.Slider(
+                minimum=0.01, maximum=1.0, step=0.01, value=_default_top_p,
+                label="Top P",
+                info="Nucleus sampling threshold. 1.0 = disabled.",
+            )
+            rep_penalty_slider = gr.Slider(
+                minimum=1.0, maximum=2.0, step=0.05, value=_default_rep,
+                label="Repetition Penalty",
+                info="1.0 = no penalty. Higher discourages repeated phrases.",
+            )
+
+        def _apply_nim_defaults(checked):
+            # Toggle ON  → snap sliders to build.nvidia.com NIM defaults.
+            # Toggle OFF → no-op; preserve whatever the user has dialed in.
+            if checked:
+                t, p, r = _NIM_DEFAULTS
+                return gr.update(value=t), gr.update(value=p), gr.update(value=r)
+            return gr.update(), gr.update(), gr.update()
+
+        nim_defaults_chk.change(
+            fn=_apply_nim_defaults,
+            inputs=[nim_defaults_chk],
+            outputs=[temp_slider, top_p_slider, rep_penalty_slider],
+        )
+
+        with gr.Row(visible=INFERENCE_BACKEND != "vllm"):
+            disable_autocap_chk = gr.Checkbox(
+                label="Disable resolution auto-cap",
+                value=INFERENCE_BACKEND != "hf",
+                info=(
+                    "Auto-cap reduces max_pixels per frame so HF prefill finishes "
+                    "in ~55s on H100. Off by default on fast backends (vLLM, NIM); "
+                    "on by default on HF. Toggle to override."
+                ),
+                interactive=True,
+            )
+            if INFERENCE_BACKEND == "hf":
+                gr.HTML(
+                    '<div style="color:#f87171;font-size:12px;padding-top:4px">'
+                    '⚠ <b>Auto-cap is on by default on HF.</b> Disabling sends full-resolution '
+                    'frames; longer videos can run <b>3–5× slower</b> or OOM. Upload a video to '
+                    'see the estimated time multiplier.'
+                    '</div>'
+                )
+            else:
+                gr.HTML(
+                    '<div style="color:#475569;font-size:12px;padding-top:4px">'
+                    'Auto-cap is <b>off</b> by default on this backend — full-resolution '
+                    'frames go to the model. Auto-cap only matters for HF Transformers, '
+                    'where it keeps prefill from ballooning to many minutes per clip.'
+                    '</div>'
+                )
+
+        # Run All Variants disabled — reload checkbox hidden accordingly
+        reload_vllm_chk = gr.Checkbox(value=False, visible=False, interactive=False)
+
+        # HF auth is only relevant when the backend loads gated checkpoints from
+        # the HF Hub (HF Transformers / vLLM modes). NIM ships its own weights,
+        # so this whole block is hidden in nim_local mode to remove a confusing
+        # surface area. The "Get Login URL (browser)" button was removed because
+        # the HF device flow can't be reliably captured from inside this Gradio
+        # process (no TTY, no browser handoff) — pasting a token directly from
+        # huggingface.co/settings/tokens is the supported path.
+        _hf_auth_visible = INFERENCE_BACKEND in ("hf", "vllm")
+        with gr.Group(visible=_hf_auth_visible):
+            gr.HTML('<hr style="margin:12px 0;border:none;border-top:1px solid #444"/>')
+            gr.Markdown(
+                "**HuggingFace Auth** — required for gated models (e.g. CR2-8B BF16, CR2-8B FP8, custom checkpoints).  \n"
+                "Get a token at [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens) and paste it below."
+            )
+            with gr.Row():
+                hf_token_box = gr.Textbox(
+                    label="HF Token",
+                    placeholder="hf_...",
+                    type="password",
+                    info="Paste a token from huggingface.co/settings/tokens",
+                    scale=3,
+                    interactive=True,
+                )
+                with gr.Column(scale=1, min_width=160):
+                    hf_apply_btn  = gr.Button("Apply Token",        size="sm", variant="primary")
+                    hf_status_btn = gr.Button("Check Auth Status",  size="sm")
+            hf_auth_html = gr.HTML(_hf_check_status())
+
+            hf_apply_btn.click(fn=_hf_apply_token,    inputs=[hf_token_box], outputs=[hf_auth_html])
+            hf_status_btn.click(fn=_hf_check_status,  inputs=[],             outputs=[hf_auth_html])
+
+        gr.HTML('<hr style="margin:12px 0;border:none;border-top:1px solid #444"/>')
+        with gr.Accordion("Storage & Disk Management", open=False):
+            gr.HTML(
+                '<div style="color:#9ca3af;font-size:12px;margin-bottom:6px">'
+                'Note: Brev does not support in-place storage resize. '
+                'To add disk space you must delete and recreate the instance with a larger storage tier. '
+                'The <b>HF download cache</b> is safe to clean — model files in '
+                '<code>cosmos-reason2/models/</code> are independent copies.'
+                '</div>'
+            )
+            disk_status_out = gr.HTML(_disk_status_html())
+            with gr.Row():
+                disk_refresh_btn = gr.Button("Refresh", size="sm", scale=0, min_width=120)
+                clean_cache_btn  = gr.Button("Clean HF Download Cache", size="sm",
+                                             variant="stop", scale=0, min_width=220)
+            disk_refresh_btn.click(fn=_disk_status_html,  inputs=[], outputs=[disk_status_out])
+            clean_cache_btn.click( fn=_clean_hf_cache,    inputs=[], outputs=[disk_status_out])
+
+    # ── Output row ───────────────────────────────────────────────────────────
+    with gr.Row():
+        with gr.Column(scale=2):
+            # Initial badge state matches the first DEMO_PROMPT (which is the
+            # default selection in the dropdown). Updated by on_demo().
+            reasoning_badge = gr.HTML(
+                value=_reasoning_badge_html(DEMO_PROMPTS[0][3]),
+                show_label=False,
+            )
+            response_out = gr.HTML(label="Model Response", value="", show_label=True)
+        with gr.Column(scale=1):
+            status_panel = gr.HTML(_status_html(["wait"] * 5), show_progress="hidden")
+
+    # ── Benchmark results table ───────────────────────────────────────────────
+    results_table = gr.HTML(_table_html(), label="Benchmark Log", show_progress="hidden")
+
+    # ── Event handlers ───────────────────────────────────────────────────────
+    def on_upload(path, fps_val, disable_autocap):
+        if not path:
+            return "*Upload a video to see clip info*", gr.update()
+        m = get_video_meta(path)
+        if not m.width:
+            return "*Clip info unavailable (PyAV not installed)*", gr.update()
+        fps_val  = max(1, int(fps_val))
+        n_frames = max(1, int(m.duration_s * fps_val))
+        info_str = (f"**{m.width}×{m.height}** · {m.fps:.1f} fps · {m.duration_s:.1f}s · "
+                    f"{n_frames} frames sampled")
+        # Fast backends (vLLM, NIM) are 100-500x faster than HF — HF-based
+        # timing estimates are meaningless and auto-cap is unnecessary.
+        if INFERENCE_BACKEND in ("vllm", "nim_local"):
+            return info_str, gr.update()
+        est_s_full = _est_tokens(n_frames, DEFAULT_MAX_PIXELS) / PREFILL_TPS
+        capped_px, est_s_capped = _auto_cap(n_frames, DEFAULT_MAX_PIXELS)
+        if not disable_autocap:
+            # Auto-cap ENABLED — the exception (HF and other unoptimized backends).
+            if capped_px < DEFAULT_MAX_PIXELS:
+                ratio = est_s_full / max(est_s_capped, 1.0)
+                info_str += (
+                    f"\n> ⚠ **Auto-cap ENABLED** · capping at {capped_px:,} px/frame "
+                    f"→ ~{est_s_capped:.0f}s est "
+                    f"(full-res would be ~{est_s_full:.0f}s, **~{ratio:.1f}× slower**)"
+                )
+                return info_str, gr.update(value=capped_px)
+            info_str += f"\n> ✓ **Auto-cap ENABLED** · cap not needed for this clip · ~{est_s_full:.0f}s est"
+            return info_str, gr.update()
+        # Auto-cap DISABLED — the default. Generic + expressive.
+        info_str += "\n> ✓ **Full resolution** — every frame delivered at the native pixel count above"
+        return info_str, gr.update()
+
+    video_input.change(on_upload, inputs=[video_input, fps_slider, disable_autocap_chk], outputs=[clip_info, maxpx_slider])
+    fps_slider.change(on_upload, inputs=[video_input, fps_slider, disable_autocap_chk], outputs=[clip_info, maxpx_slider])
+    disable_autocap_chk.change(on_upload, inputs=[video_input, fps_slider, disable_autocap_chk], outputs=[clip_info, maxpx_slider])
+
+    def on_image_upload(path, disable_autocap):
+        if not path:
+            return "*Upload an image to see info*", gr.update()
+        try:
+            from PIL import Image as _pil
+            img = _pil.open(path)
+            w, h = img.size
+            info_str = f"**{w}×{h}** · {img.mode} image"
+        except Exception:
+            return "*Image info unavailable*", gr.update()
+        # Fast backends (vLLM, NIM) serve at high throughput; HF-backend
+        # timing math doesn't apply and auto-cap is unnecessary.
+        if INFERENCE_BACKEND in ("vllm", "nim_local"):
+            return info_str, gr.update()
+        est_s_full = _est_tokens(1, DEFAULT_MAX_PIXELS) / PREFILL_TPS
+        capped_px, est_s_capped = _auto_cap(1, DEFAULT_MAX_PIXELS)
+        capped_px = min(capped_px, IMAGE_AUTO_CAP_MAX)
+        if not disable_autocap:
+            # Auto-cap ENABLED — the exception (HF and other unoptimized backends).
+            if capped_px < DEFAULT_MAX_PIXELS:
+                ratio = est_s_full / max(est_s_capped, 1.0)
+                info_str += (
+                    f"\n> ⚠ **Auto-cap ENABLED** · capping at {capped_px:,} px "
+                    f"→ ~{est_s_capped:.0f}s est "
+                    f"(full-res would be ~{est_s_full:.0f}s, **~{ratio:.1f}× slower**)"
+                )
+                return info_str, gr.update(value=capped_px)
+            info_str += f"\n> ✓ **Auto-cap ENABLED** · cap not needed for this image · ~{est_s_full:.0f}s est"
+            return info_str, gr.update()
+        # Auto-cap DISABLED — the default. Generic + expressive.
+        info_str += "\n> ✓ **Full resolution** — image delivered at the native pixel count above"
+        return info_str, gr.update()
+
+    image_input.change(on_image_upload, inputs=[image_input, disable_autocap_chk], outputs=[clip_info, maxpx_slider])
+
+    def on_demo(name):
+        """Pick a demo: populate user prompt + system prompt + Reasoning badge."""
+        for entry in DEMO_PROMPTS:
+            if entry[0] == name:
+                _, user_p, system_p, reasoning_on = entry
+                return user_p, system_p, _reasoning_badge_html(reasoning_on)
+        return DEFAULT_PROMPT, DEFAULT_SYSTEM, _reasoning_badge_html(False)
+
+    demo_picker.change(
+        on_demo,
+        inputs=[demo_picker],
+        outputs=[user_box, system_box, reasoning_badge],
+    )
+
+    if INFERENCE_BACKEND == "vllm":
+        checkpoint_dd.change(
+            fn=_on_checkpoint_change,
+            inputs=[checkpoint_dd],
+            outputs=[vllm_swap_banner, download_load_btn, fps_slider, maxpx_slider],
+        )
+        download_load_btn.click(
+            fn=_on_download_and_load,
+            inputs=[checkpoint_dd],
+            outputs=[vllm_swap_banner, download_load_btn, fps_slider, maxpx_slider],
+        )
+    # nim_local: no click wiring — swap is done out-of-band (see info panel).
+
+    def resolve_model_id(ckpt_name, custom_val):
+        if custom_val.strip():
+            return custom_val.strip()
+        for name, mid in CHECKPOINT_PRESETS:
+            if name == ckpt_name:
+                return mid
+        return CHECKPOINT_PRESETS[0][1]
+
+    def _run(video_path, image_path, user_prompt, system_prompt, fps, max_pixels, max_new_tokens,
+             ckpt_name, custom_val, disable_autocap, temperature, top_p, rep_penalty):
+        model_id  = resolve_model_id(ckpt_name, custom_val)
+        media     = video_path
+        is_image  = False
+        if media is None and image_path is not None:
+            media    = image_path
+            is_image = True
+        for text, status, tbl in run_inference(
+            media, user_prompt, system_prompt,
+            fps, max_pixels, max_new_tokens, model_id,
+            disable_autocap=disable_autocap,
+            is_image=is_image,
+            temperature=temperature,
+            top_p=top_p,
+            rep_penalty=rep_penalty,
+        ):
+            yield _render_with_think(text), status, tbl
+
+    def _run_all(video_path, user_prompt, system_prompt, fps, max_pixels, max_new_tokens,
+                 disable_autocap, reload_vllm):
+        for combined, status, tbl in run_all_variants(
+            video_path, user_prompt, system_prompt,
+            fps, max_pixels, max_new_tokens,
+            disable_autocap=disable_autocap,
+            reload_vllm=reload_vllm,
+        ):
+            yield _render_with_think(combined), status, tbl
+
+    run_btn.click(
+        fn=_run,
+        inputs=[video_input, image_input, user_box, system_box, fps_slider, maxpx_slider, maxtok_slider,
+                checkpoint_dd, custom_ckpt, disable_autocap_chk,
+                temp_slider, top_p_slider, rep_penalty_slider],
+        outputs=[response_out, status_panel, results_table],
+    )
+
+    all_btn.click(
+        fn=_run_all,
+        inputs=[video_input, user_box, system_box, fps_slider, maxpx_slider, maxtok_slider,
+                disable_autocap_chk, reload_vllm_chk],
+        outputs=[response_out, status_panel, results_table],
+    )
+
+    SAMPLE_VIDEO = f"{HOME}/cosmos-reason2/assets/sample.mp4"
+    if os.path.exists(SAMPLE_VIDEO):
+        gr.Examples(
+            examples=[[SAMPLE_VIDEO, DEFAULT_PROMPT, DEFAULT_SYSTEM,
+                       DEFAULT_FPS, DEFAULT_MAX_PIXELS, DEFAULT_MAX_TOKENS]],
+            inputs=[video_input, user_box, system_box, fps_slider, maxpx_slider, maxtok_slider],
+            label="Sample video",
+        )
+
+_app, _local_url, _share_url = demo.launch(
+    server_name="0.0.0.0", server_port=PORT, share=SHARE, prevent_thread_lock=True,
+    theme=gr.themes.Base(primary_hue="green", font=gr.themes.GoogleFont("Inter")),
+)
+_pub = _share_url or _local_url or f"http://0.0.0.0:{PORT}"
+print(f"[launch] {_pub}", flush=True)
+try:
+    with open("/tmp/gradio_url.txt", "w") as _f:
+        _f.write(_pub)
+except Exception:
+    pass
+demo.block_thread()

--- a/.claude/scripts/nim_catalog.py
+++ b/.claude/scripts/nim_catalog.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+nim_catalog.py — VLM NIM catalog helper for /byo-video.
+
+Single source of truth: the agents always re-check
+  https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html
+PLUS every versioned release-notes page in KNOWN_RELEASE_VERSIONS, so the
+catalog reflects what NVIDIA ships AND what older NIM containers are still
+pullable from nvcr.io. Walking release notes is required because
+introduction.html only lists models in the CURRENT release; older models
+(e.g. Cosmos Reason 1 7B from <1.5) drop off its table even though their
+images still work.
+
+How it works:
+  1. fetch_supported_models() — GETs introduction.html and every
+     release-notes page; merges the model-name columns. Per-page parse is
+     fault-tolerant; if any URL fails, the others still contribute.
+     No nvcr.io paths or served model IDs are exposed at this level
+     (those live in per-model cards), so KNOWN_VLM_NIMS below maps display
+     names to image short-IDs and per-NIM metadata (VRAM, video support).
+  2. KNOWN_VLM_NIMS — the slug map. Update when a new VLM family is
+     added upstream (the agents are told to do this when fetch finds a
+     name not in the map). Each entry carries supports_video — set False
+     for image-only NIMs so /byo-video filters them out of its dropdown.
+  3. list_available_nims(ngc_api_key, vram_mb=None) — intersects the
+     upstream catalog with the slug map, then probes each candidate
+     image via `docker manifest inspect` to confirm the user's
+     NGC_API_KEY actually has access. Optionally filters by min VRAM.
+  4. list_video_nims() — quick filter for /byo-video population.
+  5. CLI: `python3 nim_catalog.py list [--vram MB]` → prints JSON.
+
+Network failures fall back to the slug map alone (no upstream filter).
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from typing import List, Optional
+
+DOCS_URL = "https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html"
+
+# Versioned release-notes pages. introduction.html only lists models in the
+# CURRENT release; older models (e.g. Cosmos Reason 1 7B from <1.5) drop off
+# its table even though their containers are still pullable from nvcr.io.
+# Fetching every known release-notes page and unioning keeps older Cosmos +
+# Llama variants discoverable. Add new versions here as NVIDIA ships them.
+RELEASE_NOTES_URL_FMT = "https://docs.nvidia.com/nim/vision-language-models/{version}/release-notes.html"
+KNOWN_RELEASE_VERSIONS = [
+    "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0",
+    "1.5.0", "1.6.0", "1.7.0",
+]
+
+
+@dataclass
+class NimImage:
+    short_id: str           # e.g. "cosmos-reason2-8b"
+    image: str              # e.g. "nvcr.io/nim/nvidia/cosmos-reason2-8b:latest"
+    family: str             # e.g. "Cosmos Reason2"
+    label: str              # human-readable label for the dropdown
+    served_model_id: str    # e.g. "nvidia/cosmos-reason2-8b" (best-effort)
+    min_vram_mb: int = 0    # 0 if unknown
+    supports_video: bool = True   # True = video frames; False = single image only
+    notes: str = ""
+
+
+# Slug + min-VRAM map — translates display names from introduction.html
+# into actual nvcr.io short-IDs. Conservative VRAM minimums; refine per
+# model card. Add new entries here when the upstream catalog grows.
+#
+# supports_video: which models accept multi-frame video input vs single
+# images only. Sourced from each model card on
+# https://docs.nvidia.com/nim/vision-language-models/1.7.0/release-notes.html
+# (cross-referenced against build.nvidia.com per-model docs). When in
+# doubt, set False; agents can always upgrade after reading the card.
+#
+KNOWN_VLM_NIMS = [
+    # ── Cosmos Reason2 family (NVIDIA, video-native) ─────────────────────
+    NimImage("cosmos-reason2-2b",  "nvcr.io/nim/nvidia/cosmos-reason2-2b:latest",
+             "Cosmos Reason2", "Cosmos Reason2 2B (NIM)",
+             "nvidia/cosmos-reason2-2b", min_vram_mb=20000, supports_video=True,
+             notes="FP8 quantized; reasoning VLM; speculative decoding; "
+                   "needs temperature ≥ 0.3 to avoid <think>+EOS bug at greedy decode. "
+                   "Container only — NOT on build.nvidia.com hosted API."),
+    NimImage("cosmos-reason2-8b",  "nvcr.io/nim/nvidia/cosmos-reason2-8b:latest",
+             "Cosmos Reason2", "Cosmos Reason2 8B (NIM)",
+             "nvidia/cosmos-reason2-8b", min_vram_mb=40000, supports_video=True,
+             notes="FP8 quantized; reasoning VLM; Efficient Video Sampling (EVS); "
+                   "needs temperature ≥ 0.3 to avoid <think>+EOS bug at greedy decode. "
+                   "Container + build.nvidia.com hosted API."),
+    NimImage("cosmos-reason2-32b", "nvcr.io/nim/nvidia/cosmos-reason2-32b:latest",
+             "Cosmos Reason2", "Cosmos Reason2 32B (NIM)",
+             "nvidia/cosmos-reason2-32b", min_vram_mb=80000, supports_video=True,
+             notes="May require allowlisting via build.nvidia.com (not in default NGC catalog)."),
+    NimImage("cosmos-reason1-7b",  "nvcr.io/nim/nvidia/cosmos-reason1-7b:latest",
+             "Cosmos Reason1 7B", "Cosmos Reason1 7B (NIM)",
+             "nvidia/cosmos-reason1-7b", min_vram_mb=24000, supports_video=True),
+
+    # ── Nemotron family (NVIDIA) ─────────────────────────────────────────
+    NimImage("nemotron-3-nano-omni-30b-a3b-reasoning",
+             "nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest",
+             "NVIDIA Nemotron 3 Nano Omni",
+             "Nemotron 3 Nano Omni 30B (NIM)",
+             "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+             min_vram_mb=40000, supports_video=True,
+             notes="Specialized container variant; release 1.7.0+."),
+    NimImage("nemotron-nano-12b-v2-vl",
+             "nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl:latest",
+             "Nemotron Nano 12B v2 VL", "Nemotron Nano 12B v2 VL (NIM)",
+             "nvidia/nemotron-nano-12b-v2-vl",
+             min_vram_mb=40000, supports_video=True),
+    NimImage("nemotron-parse-v1.2",
+             "nvcr.io/nim/nvidia/nemotron-parse-v1.2:latest",
+             "Nemotron-Parse-v1.2", "Nemotron Parse v1.2 (NIM)",
+             "nvidia/nemotron-parse-v1.2", min_vram_mb=24000,
+             supports_video=False,
+             notes="Image parsing only; document-extraction VLM. Not for /byo-video."),
+    NimImage("nemotron-3-content-safety",
+             "nvcr.io/nim/nvidia/nemotron-3-content-safety:latest",
+             "Nemotron-3-Content-Safety", "Nemotron 3 Content Safety (NIM)",
+             "nvidia/nemotron-3-content-safety", min_vram_mb=24000,
+             supports_video=False,
+             notes="Safety classifier; not a generative VLM."),
+
+    # ── Llama family (Meta) ──────────────────────────────────────────────
+    NimImage("llama-3.1-nemotron-nano-vl-8b-v1",
+             "nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1:latest",
+             "Llama 3.1 Nemotron Nano VL 8B v1",
+             "Llama 3.1 Nemotron Nano VL 8B (NIM)",
+             "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+             min_vram_mb=40000, supports_video=False,
+             notes="Image input only; no multi-frame video."),
+    NimImage("llama-3.2-11b-vision-instruct",
+             "nvcr.io/nim/meta/llama-3.2-11b-vision-instruct:latest",
+             "Llama 3.2 11B Vision Instruct",
+             "Llama 3.2 11B Vision Instruct (NIM)",
+             "meta/llama-3.2-11b-vision-instruct",
+             min_vram_mb=40000, supports_video=False,
+             notes="Image input only."),
+    NimImage("llama-3.2-90b-vision-instruct",
+             "nvcr.io/nim/meta/llama-3.2-90b-vision-instruct:latest",
+             "Llama 3.2 90B Vision Instruct",
+             "Llama 3.2 90B Vision Instruct (NIM)",
+             "meta/llama-3.2-90b-vision-instruct",
+             min_vram_mb=160000, supports_video=False,
+             notes="Image input only. Multi-GPU only (~160GB+ VRAM)."),
+    NimImage("llama-4-maverick-17b-128e-instruct",
+             "nvcr.io/nim/meta/llama-4-maverick-17b-128e-instruct:latest",
+             "Llama 4 Maverick 17B 128E Instruct",
+             "Llama 4 Maverick 17B (NIM)",
+             "meta/llama-4-maverick-17b-128e-instruct",
+             min_vram_mb=80000, supports_video=False),
+    NimImage("llama-4-scout-17b-16e-instruct",
+             "nvcr.io/nim/meta/llama-4-scout-17b-16e-instruct:latest",
+             "Llama 4 Scout 17B 16E Instruct",
+             "Llama 4 Scout 17B (NIM)",
+             "meta/llama-4-scout-17b-16e-instruct",
+             min_vram_mb=80000, supports_video=False),
+
+    # ── Mistral family ───────────────────────────────────────────────────
+    NimImage("mistral-medium-3.5-128b",
+             "nvcr.io/nim/mistralai/mistral-medium-3.5-128b:latest",
+             "Mistral Medium 3.5", "Mistral Medium 3.5 128B (NIM)",
+             "mistralai/mistral-medium-3.5-128b",
+             min_vram_mb=140000, supports_video=False,
+             notes="Image + text only; no video. Multi-GPU."),
+    NimImage("mistral-small-4-119b-2603",
+             "nvcr.io/nim/mistralai/mistral-small-4-119b-2603:latest",
+             "Mistral-Small-4-119B-2603", "Mistral Small 4 119B (NIM)",
+             "mistralai/mistral-small-4-119b-2603",
+             min_vram_mb=140000, supports_video=False,
+             notes="Text + image only; no video. Multi-GPU."),
+    NimImage("mistral-small-3.2-24b-instruct-2506",
+             "nvcr.io/nim/mistralai/mistral-small-3.2-24b-instruct-2506:latest",
+             "Mistral Small 3.2 24B Instruct 2506",
+             "Mistral Small 3.2 24B (NIM)",
+             "mistralai/mistral-small-3.2-24b-instruct-2506",
+             min_vram_mb=60000, supports_video=False),
+    NimImage("ministral-14b-instruct-2512",
+             "nvcr.io/nim/mistralai/ministral-14b-instruct-2512:latest",
+             "Ministral 3 14B Instruct 2512",
+             "Ministral 3 14B (NIM)",
+             "mistralai/ministral-14b-instruct-2512",
+             min_vram_mb=40000, supports_video=True,
+             notes="Tool calling; 100k context on L40S."),
+    NimImage("mistral-large-3-675b-instruct-2512",
+             "nvcr.io/nim/mistralai/mistral-large-3-675b-instruct-2512:latest",
+             "Mistral Large 3 675B Instruct 2512",
+             "Mistral Large 3 675B (NIM)",
+             "mistralai/mistral-large-3-675b-instruct-2512",
+             min_vram_mb=400000, supports_video=False,
+             notes="Frontier-scale; multi-node inference."),
+
+    # ── Qwen family (Alibaba) ────────────────────────────────────────────
+    NimImage("qwen3.5-35b-a3b",
+             "nvcr.io/nim/qwen/qwen3.5-35b-a3b:latest",
+             "Qwen3.5", "Qwen3.5 35B A3B (NIM)",
+             "qwen/qwen3.5-35b-a3b",
+             min_vram_mb=40000, supports_video=True,
+             notes="MoE; high-concurrency video constraints noted in card."),
+    NimImage("qwen3.5-122b-a10b",
+             "nvcr.io/nim/qwen/qwen3.5-122b-a10b:latest",
+             "Qwen3.5", "Qwen3.5 122B A10B (NIM)",
+             "qwen/qwen3.5-122b-a10b",
+             min_vram_mb=140000, supports_video=True,
+             notes="MoE; KV cache saturation risk on long video. Multi-GPU."),
+    NimImage("qwen3.5-397b-a17b",
+             "nvcr.io/nim/qwen/qwen3.5-397b-a17b:latest",
+             "Qwen3.5", "Qwen3.5 397B A17B (NIM)",
+             "qwen/qwen3.5-397b-a17b",
+             min_vram_mb=400000, supports_video=True,
+             notes="Video input not enabled by default — config flag required. Multi-node."),
+    NimImage("qwen3.6-27b",
+             "nvcr.io/nim/qwen/qwen3.6-27b:latest",
+             "Qwen3.6-27B", "Qwen3.6 27B (NIM)",
+             "qwen/qwen3.6-27b",
+             min_vram_mb=40000, supports_video=False,
+             notes="Image + text only; no video."),
+    NimImage("qwen3.6-35b-a3b",
+             "nvcr.io/nim/qwen/qwen3.6-35b-a3b:latest",
+             "Qwen3.6-35B-A3B", "Qwen3.6 35B A3B (NIM)",
+             "qwen/qwen3.6-35b-a3b",
+             min_vram_mb=40000, supports_video=True,
+             notes="MoE; SGLang backend; video concurrency constraints."),
+
+    # ── Moonshot Kimi family ─────────────────────────────────────────────
+    NimImage("kimi-k2.5",
+             "nvcr.io/nim/moonshotai/kimi-k2.5:latest",
+             "Kimi-K2.5", "Kimi K2.5 (NIM)",
+             "moonshotai/kimi-k2.5",
+             min_vram_mb=140000, supports_video=False,
+             notes="Text + image only; no video. Multi-GPU."),
+    NimImage("kimi-k2.6",
+             "nvcr.io/nim/moonshotai/kimi-k2.6:latest",
+             "Kimi-K2.6", "Kimi K2.6 (NIM)",
+             "moonshotai/kimi-k2.6",
+             min_vram_mb=140000, supports_video=False,
+             notes="Does not support video workloads. Multi-GPU."),
+
+    # ── Google Gemma family ──────────────────────────────────────────────
+    NimImage("gemma-4-31b-it",
+             "nvcr.io/nim/google/gemma-4-31b-it:latest",
+             "Gemma 4 31B Instruct", "Gemma 4 31B Instruct (NIM)",
+             "google/gemma-4-31b-it",
+             min_vram_mb=40000, supports_video=True,
+             notes="Structured output not supported on this NIM."),
+]
+
+
+def list_video_nims() -> List["NimImage"]:
+    """Subset of KNOWN_VLM_NIMS that accepts multi-frame video input.
+    Use this for /byo-video dropdown population — image-only NIMs would
+    error out on the standard frame-extraction pipeline."""
+    return [n for n in KNOWN_VLM_NIMS if n.supports_video]
+
+
+def _fetch_url_body(url: str, timeout: int = 10) -> str:
+    """Fetch a URL with the standard User-Agent. Returns "" on any failure."""
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "byo-video-skill nim_catalog/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read().decode("utf-8", errors="ignore")
+    except Exception:
+        return ""
+
+
+def _extract_model_names_from_table(body: str) -> List[str]:
+    """Pull model names from the first column of every <tr> in the page.
+    Skips version-string cells and "Release notes" link cells."""
+    names: List[str] = []
+    _version_re = re.compile(r"^\d+(\.\d+){1,3}")
+    for row in re.findall(r"<tr[^>]*>(.*?)</tr>", body, re.DOTALL | re.IGNORECASE):
+        cells = re.findall(r"<t[dh][^>]*>(.*?)</t[dh]>", row, re.DOTALL | re.IGNORECASE)
+        if not cells:
+            continue
+        raw = cells[0]
+        # Prefer text inside <a>...</a> if present (link text == model name).
+        m = re.search(r"<a[^>]*>(.*?)</a>", raw, re.DOTALL | re.IGNORECASE)
+        text = m.group(1) if m else raw
+        text = re.sub(r"<[^>]+>", "", text)
+        text = html.unescape(text).strip()
+        if not text or text.lower() in ("model", ""):
+            continue
+        if _version_re.match(text) or text.lower().startswith("release notes"):
+            continue
+        names.append(text)
+    return names
+
+
+def fetch_supported_models(timeout: int = 10, include_release_notes: bool = True) -> List[str]:
+    """Return the union of model names listed across:
+      - https://docs.nvidia.com/nim/vision-language-models/latest/introduction.html
+      - every release-notes page in KNOWN_RELEASE_VERSIONS (when
+        include_release_notes is True — default).
+
+    Walking the release notes is what keeps older models like Cosmos Reason 1
+    7B in the catalog even though they no longer appear on introduction.html.
+
+    Returns [] on total network failure (callers must tolerate that)."""
+    seen: set = set()
+    out: List[str] = []
+
+    body = _fetch_url_body(DOCS_URL, timeout=timeout)
+    for n in _extract_model_names_from_table(body):
+        if n not in seen:
+            seen.add(n); out.append(n)
+
+    if include_release_notes:
+        for version in KNOWN_RELEASE_VERSIONS:
+            url = RELEASE_NOTES_URL_FMT.format(version=version)
+            rn_body = _fetch_url_body(url, timeout=timeout)
+            if not rn_body:
+                continue
+            for n in _extract_model_names_from_table(rn_body):
+                if n not in seen:
+                    seen.add(n); out.append(n)
+
+    return out
+
+
+def _matches_family(name: str, family: str) -> bool:
+    """Loose match: introduction.html sometimes prints 'Cosmos Reason2'
+    while we want to match all sizes (2B/8B/32B). Compare lowercased
+    prefix-form, ignoring punctuation differences."""
+    norm = lambda s: re.sub(r"[^a-z0-9]+", "", s.lower())
+    return norm(family) in norm(name) or norm(name) in norm(family)
+
+
+def probe_image(image: str, timeout: int = 30) -> bool:
+    """Return True if `docker manifest inspect <image>` succeeds. Requires a
+    prior `docker login nvcr.io` to have populated ~/.docker/config.json."""
+    try:
+        r = subprocess.run(
+            ["docker", "manifest", "inspect", image],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def list_available_nims(
+    ngc_api_key: Optional[str] = None,
+    vram_mb: Optional[int] = None,
+    use_upstream: bool = True,
+    do_probe: bool = True,
+) -> List[NimImage]:
+    """Return the subset of KNOWN_VLM_NIMS that:
+      - has a family name present on DOCS_URL (when use_upstream and reachable),
+      - fits in vram_mb if given,
+      - passes a `docker manifest inspect` probe when do_probe.
+    `ngc_api_key` is informational only — `docker login nvcr.io` must already
+    have been done for probing to work."""
+    upstream_names: List[str] = fetch_supported_models() if use_upstream else []
+    out: List[NimImage] = []
+    for nim in KNOWN_VLM_NIMS:
+        if upstream_names and not any(_matches_family(n, nim.family) for n in upstream_names):
+            continue
+        if vram_mb is not None and nim.min_vram_mb and nim.min_vram_mb > vram_mb:
+            continue
+        if do_probe and not probe_image(nim.image):
+            continue
+        out.append(nim)
+    return out
+
+
+def main(argv: List[str]) -> int:
+    p = argparse.ArgumentParser(description="VLM NIM catalog helper")
+    sp = p.add_subparsers(dest="cmd", required=True)
+    pl = sp.add_parser("list", help="List available NIMs as JSON")
+    pl.add_argument("--vram", type=int, default=None,
+                    help="Filter by max VRAM available on target (MB)")
+    pl.add_argument("--no-upstream", action="store_true",
+                    help="Skip fetching docs.nvidia.com (use slug map only)")
+    pl.add_argument("--no-probe", action="store_true",
+                    help="Skip `docker manifest inspect` probes")
+    sp.add_parser("upstream", help="Print model names from docs.nvidia.com")
+    args = p.parse_args(argv)
+
+    if args.cmd == "upstream":
+        names = fetch_supported_models()
+        print(json.dumps(names, indent=2))
+        return 0
+    if args.cmd == "list":
+        nims = list_available_nims(
+            ngc_api_key=os.environ.get("NGC_API_KEY"),
+            vram_mb=args.vram,
+            use_upstream=not args.no_upstream,
+            do_probe=not args.no_probe,
+        )
+        print(json.dumps([asdict(n) for n in nims], indent=2))
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/scripts/nim_launch.sh
+++ b/.claude/scripts/nim_launch.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# NIM launch script for any Cosmos Reason 2 NIM (2B / 8B / 32B) on any host.
+# Run as: bash nim_launch.sh <NGC_API_KEY> [HF_TOKEN]
+# Env overrides:
+#   MODEL            — short id: cosmos-reason2-8b (default) | cosmos-reason2-2b | cosmos-reason2-32b
+#   IMAGE            — full image override (defaults to nvcr.io/nim/nvidia/$MODEL:latest)
+#   PORT             — host port (default 8000)
+#   CONTAINER_NAME   — docker container name (default cosmos-nim)
+#   LOCAL_NIM_CACHE  — host cache dir (default $HOME/.cache/nim)
+#   MAX_WAIT         — seconds to wait for /v1/models (default 1800; first-pull + first-load can be long)
+#   SHM_SIZE         — --shm-size value (default 32GB)
+#
+# Output: detached container on $PORT serving OpenAI-compatible API at http://localhost:$PORT/v1.
+# Logs streamed to /tmp/nim_launch.log; container logs via `docker logs $CONTAINER_NAME`.
+
+set -e
+NGC_API_KEY="${1:-${NGC_API_KEY:-}}"
+HF_TOKEN="${2:-${HF_TOKEN:-}}"
+
+MODEL="${MODEL:-cosmos-reason2-8b}"
+IMAGE="${IMAGE:-nvcr.io/nim/nvidia/${MODEL}:latest}"
+PORT="${PORT:-8000}"
+CONTAINER_NAME="${CONTAINER_NAME:-cosmos-nim}"
+LOCAL_NIM_CACHE="${LOCAL_NIM_CACHE:-$HOME/.cache/nim}"
+MAX_WAIT="${MAX_WAIT:-1800}"
+SHM_SIZE="${SHM_SIZE:-32GB}"
+
+LOG=/tmp/nim_launch.log
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== NIM launch $(date) ==="
+echo "MODEL=$MODEL"
+echo "IMAGE=$IMAGE"
+echo "PORT=$PORT"
+echo "CONTAINER_NAME=$CONTAINER_NAME"
+echo "LOCAL_NIM_CACHE=$LOCAL_NIM_CACHE"
+echo "HOME=$HOME"
+
+if [ -z "$NGC_API_KEY" ]; then
+    echo "ERROR: NGC_API_KEY required as first argument or env var"
+    echo "Usage: bash nim_launch.sh <NGC_API_KEY> [HF_TOKEN]"
+    exit 1
+fi
+
+# 0. Idempotency: if a container of this name is already running AND /v1/models
+#    is healthy, reuse it. This protects in-progress first-run model downloads.
+if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    if curl -sf "http://localhost:${PORT}/v1/models" >/dev/null 2>&1; then
+        echo "Container $CONTAINER_NAME is already running and healthy on port $PORT — reusing."
+        echo "API endpoint: http://localhost:${PORT}/v1"
+        exit 0
+    fi
+    echo "Container $CONTAINER_NAME is running but /v1/models not yet ready — leaving it alone."
+    echo "If you want to force a restart: docker rm -f $CONTAINER_NAME && rerun this script."
+    # Fall through to wait loop on the existing container.
+    SKIP_LAUNCH=1
+fi
+
+# 1. Authenticate with nvcr.io (idempotent)
+if [ -z "${SKIP_LAUNCH:-}" ]; then
+    echo "Logging into nvcr.io..."
+    echo "$NGC_API_KEY" | docker login nvcr.io --username '$oauthtoken' --password-stdin
+fi
+
+# 2. Pull image (resumes if already pulled)
+if [ -z "${SKIP_LAUNCH:-}" ]; then
+    echo "Pulling $IMAGE (first pull ~10-30 min depending on model size)..."
+    docker pull "$IMAGE"
+fi
+
+# 3. Stop + remove any existing container with the same name (only if we are launching fresh)
+if [ -z "${SKIP_LAUNCH:-}" ]; then
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+fi
+
+# 4. Ensure NIM cache dir exists with proper perms
+mkdir -p "$LOCAL_NIM_CACHE"
+
+if [ -z "${SKIP_LAUNCH:-}" ]; then
+    # 5. Free any existing process on $PORT (best-effort, ignores failure)
+    if command -v fuser &>/dev/null; then
+        fuser -k "${PORT}/tcp" 2>/dev/null || true
+    fi
+
+    # 6. Launch container in detached mode (mirrors official docker run from build.nvidia.com)
+    echo "Starting NIM container on port $PORT..."
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        --gpus all \
+        --ipc host \
+        --shm-size="$SHM_SIZE" \
+        -e NGC_API_KEY="$NGC_API_KEY" \
+        -v "$LOCAL_NIM_CACHE:/opt/nim/.cache" \
+        -u "$(id -u)" \
+        -p "${PORT}:8000" \
+        "$IMAGE"
+fi
+
+# 7. Wait for /v1/models (model download + load can be lengthy on first run)
+echo "Waiting for NIM /v1/models on http://localhost:${PORT} (max ${MAX_WAIT}s)..."
+ELAPSED=0
+INTERVAL=10
+READY=0
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+    BODY=$(curl -sf "http://localhost:${PORT}/v1/models" 2>/dev/null || echo "")
+    if [ -n "$BODY" ]; then
+        echo "NIM is ready!"
+        echo "$BODY"
+        READY=1
+        break
+    fi
+    # Check container is still running
+    if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+        echo "ERROR: container $CONTAINER_NAME exited prematurely. Last logs:"
+        docker logs --tail 80 "$CONTAINER_NAME" 2>&1 || true
+        exit 2
+    fi
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+    if [ $((ELAPSED % 60)) -eq 0 ]; then
+        echo "  ...still waiting (${ELAPSED}s elapsed)"
+    fi
+done
+
+if [ $READY -eq 0 ]; then
+    echo "ERROR: NIM did not respond within ${MAX_WAIT}s. Container logs:"
+    docker logs --tail 100 "$CONTAINER_NAME" 2>&1 || true
+    exit 3
+fi
+
+echo "=== NIM launch complete ==="
+echo "API endpoint: http://localhost:${PORT}/v1"
+echo "Test:  curl http://localhost:${PORT}/v1/models"
+echo "Logs:  docker logs -f $CONTAINER_NAME"
+echo ""
+echo "To launch Gradio with NIM backend:"
+echo "  INFERENCE_BACKEND=nim_local VLLM_BASE_URL=http://localhost:${PORT}/v1 python3 /tmp/gradio_cr2_byo.py"

--- a/.claude/scripts/smoke_cr2_byo.py
+++ b/.claude/scripts/smoke_cr2_byo.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Headless BYO-video smoke test for Cosmos Reason2.
+Usage: BYO_VIDEO=/path/to/video.mp4 MODEL_NAME=nvidia/Cosmos-Reason2-2B python smoke_cr2_byo.py
+"""
+import os, json, time, warnings
+warnings.filterwarnings("ignore")
+
+import torch
+import transformers
+
+from transformers import video_processing_utils
+from transformers.video_utils import load_video as _load_video
+
+def _patched_fetch_videos(self, video_url_or_urls, sample_indices_fn=None):
+    if isinstance(video_url_or_urls, list):
+        return list(zip(*[
+            _patched_fetch_videos(self, x, sample_indices_fn=sample_indices_fn)
+            for x in video_url_or_urls
+        ]))
+    return _load_video(video_url_or_urls, backend="pyav", sample_indices_fn=sample_indices_fn)
+
+video_processing_utils.BaseVideoProcessor.fetch_videos = _patched_fetch_videos
+print("[smoke] PyAV backend patch applied", flush=True)
+
+BYO_VIDEO = os.environ.get("BYO_VIDEO", "/home/shadeform/cosmos-reason2/assets/sample.mp4")
+MODEL_NAME = os.environ.get("MODEL_NAME", "nvidia/Cosmos-Reason2-2B")
+MODEL_DIR  = os.environ.get("MODEL_DIR", MODEL_NAME)
+OUT_FILE   = os.environ.get("OUT_FILE", "/tmp/byo_video_reason2_results.json")
+PROMPT     = os.environ.get("REASON2_PROMPT", "Describe this video in detail.")
+
+import subprocess
+gpu_info = subprocess.check_output(
+    ["nvidia-smi", "--query-gpu=name,memory.free,memory.total", "--format=csv,noheader"],
+    text=True
+).strip()
+print(f"[smoke] GPU: {gpu_info}", flush=True)
+print(f"[smoke] Model: {MODEL_NAME}", flush=True)
+print(f"[smoke] Video: {BYO_VIDEO}", flush=True)
+
+PIXELS_PER_TOKEN = 32 ** 2
+
+t0 = time.time()
+print("[smoke] Loading model...", flush=True)
+model = transformers.Qwen3VLForConditionalGeneration.from_pretrained(
+    MODEL_DIR,
+    dtype=torch.float16,
+    device_map="auto",
+    attn_implementation="sdpa",
+)
+processor = transformers.Qwen3VLProcessor.from_pretrained(MODEL_DIR)
+processor.image_processor.size = {
+    "shortest_edge": 256 * PIXELS_PER_TOKEN,
+    "longest_edge":  4096 * PIXELS_PER_TOKEN,
+}
+processor.video_processor.size = {
+    "shortest_edge": 256 * PIXELS_PER_TOKEN,
+    "longest_edge":  4096 * PIXELS_PER_TOKEN,
+}
+load_time = time.time() - t0
+print(f"[smoke] Model loaded in {load_time:.1f}s", flush=True)
+
+conversation = [
+    {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant that analyzes videos."}]},
+    {"role": "user",   "content": [
+        {"type": "video", "video": BYO_VIDEO},
+        {"type": "text",  "text": PROMPT},
+    ]},
+]
+
+t1 = time.time()
+inputs = processor.apply_chat_template(
+    conversation, tokenize=True, add_generation_prompt=True,
+    return_dict=True, return_tensors="pt", fps=4,
+)
+inputs = {k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+print("[smoke] Inputs prepared, generating...", flush=True)
+
+with torch.inference_mode():
+    out_ids = model.generate(**inputs, max_new_tokens=256, do_sample=False)
+
+n = inputs["input_ids"].shape[1]
+response = processor.decode(out_ids[0][n:], skip_special_tokens=True)
+infer_time = time.time() - t1
+
+result = {
+    "recipe":      "reason2/byo_video",
+    "provider":    os.environ.get("PROVIDER", "local"),
+    "model":       MODEL_NAME,
+    "gpu":         gpu_info,
+    "byo_video":   BYO_VIDEO,
+    "prompt":      PROMPT,
+    "response":    response,
+    "load_time_s": round(load_time, 1),
+    "infer_time_s": round(infer_time, 1),
+    "status":      "success",
+}
+
+with open(OUT_FILE, "w") as f:
+    json.dump(result, f, indent=2)
+
+print(f"\n[smoke] Done in {infer_time:.1f}s inference / {load_time:.1f}s load")
+print(f"[smoke] Response: {response[:200]}")
+print(f"[smoke] Results written to {OUT_FILE}")
+print(json.dumps(result, indent=2))

--- a/.claude/scripts/smoke_nem_vl.py
+++ b/.claude/scripts/smoke_nem_vl.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Smoke test for Nemotron/Qwen3-VL vLLM endpoint.
+
+Usage:
+    python3 smoke_nem_vl.py                          # default: localhost:8000
+    VLLM_BASE_URL=http://host:8000/v1 python3 smoke_nem_vl.py
+    TEST_VIDEO=/path/to/video.mp4 python3 smoke_nem_vl.py
+
+Exit codes:
+    0 = PASS
+    1 = FAIL (model error, empty response, or HTTP error)
+    2 = SKIP (endpoint not reachable)
+"""
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import shutil
+import tempfile
+
+VLLM_URL  = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+TIMEOUT_S = int(os.environ.get("SMOKE_TIMEOUT_S", "120"))
+
+VIDEO_PATH = os.environ.get("TEST_VIDEO", "/tmp/smoke_test_video.mp4")
+
+# Small public-domain MP4 (Big Buck Bunny 5-second clip, ~120 KB)
+_SAMPLE_URL = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4"
+
+def _download_video():
+    if os.path.exists(VIDEO_PATH) and os.path.getsize(VIDEO_PATH) > 1000:
+        return True
+    print(f"  Downloading test video → {VIDEO_PATH} ...", end=" ", flush=True)
+    try:
+        with urllib.request.urlopen(_SAMPLE_URL, timeout=30) as resp:
+            with open(VIDEO_PATH, "wb") as f:
+                f.write(resp.read(5 * 1024 * 1024))  # cap at 5 MB
+        print("done")
+        return True
+    except Exception as e:
+        print(f"FAILED ({e})")
+        return False
+
+
+def _get_serving_model():
+    try:
+        req = urllib.request.Request(f"{VLLM_URL}/models")
+        with urllib.request.urlopen(req, timeout=10) as r:
+            data = json.loads(r.read())
+            ids = [m["id"] for m in data.get("data", [])]
+            return ids[0] if ids else None
+    except Exception:
+        return None
+
+
+def _check_reachable():
+    try:
+        urllib.request.urlopen(f"{VLLM_URL}/models", timeout=5)
+        return True
+    except Exception:
+        return False
+
+
+def run_smoke():
+    print("=" * 60)
+    print("  Nemotron/Qwen3-VL vLLM Smoke Test")
+    print(f"  Endpoint: {VLLM_URL}")
+    print("=" * 60)
+
+    # 1. Reachability
+    print("\n[1/4] Checking endpoint reachability ...", end=" ", flush=True)
+    if not _check_reachable():
+        print("UNREACHABLE")
+        print(f"\n  SKIP — {VLLM_URL} is not responding. Is vLLM running?")
+        sys.exit(2)
+    print("OK")
+
+    # 2. Discover model ID
+    print("[2/4] Discovering serving model ...", end=" ", flush=True)
+    model_id = _get_serving_model()
+    if not model_id:
+        print("FAIL — /v1/models returned no models")
+        sys.exit(1)
+    print(f"OK ({model_id})")
+
+    # 3. Video
+    print("[3/4] Preparing test video ...", end=" ", flush=True)
+    if not _download_video():
+        print("FAIL — could not obtain test video")
+        sys.exit(1)
+    print(f"OK ({VIDEO_PATH}, {os.path.getsize(VIDEO_PATH)//1024} KB)")
+
+    # 4. Inference
+    file_url = f"file://{VIDEO_PATH}"
+    payload = {
+        "model": model_id,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": file_url}},
+                    {"type": "text", "text": "In one sentence, what is happening in this video?"},
+                ],
+            }
+        ],
+        "max_tokens": 128,
+        "temperature": 0.0,
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{VLLM_URL}/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    print(f"[4/4] Running inference (timeout {TIMEOUT_S}s) ...")
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as r:
+            elapsed = time.time() - t0
+            raw = r.read()
+            data = json.loads(raw)
+    except urllib.error.HTTPError as e:
+        elapsed = time.time() - t0
+        err_body = e.read().decode(errors="replace")
+        print(f"\n  FAIL — HTTP {e.code} after {elapsed:.1f}s")
+        print(f"  Error body: {err_body[:500]}")
+        sys.exit(1)
+    except Exception as e:
+        elapsed = time.time() - t0
+        print(f"\n  FAIL — {type(e).__name__}: {e} (after {elapsed:.1f}s)")
+        sys.exit(1)
+
+    # Validate response
+    choices = data.get("choices", [])
+    if not choices:
+        print(f"\n  FAIL — No choices in response: {json.dumps(data)[:300]}")
+        sys.exit(1)
+
+    text = choices[0].get("message", {}).get("content", "").strip()
+    if not text:
+        print(f"\n  FAIL — Empty content in response: {json.dumps(data)[:300]}")
+        sys.exit(1)
+
+    # Check for vLLM error markers in the content
+    err_markers = ["[VLLM ERROR]", "500 Internal", "400 Client Error", "RuntimeError"]
+    for marker in err_markers:
+        if marker in text:
+            print(f"\n  FAIL — Error marker '{marker}' found in response text")
+            print(f"  Content: {text[:300]}")
+            sys.exit(1)
+
+    usage = data.get("usage", {})
+    print(f"\n  PASS in {elapsed:.1f}s")
+    print(f"  Model:   {model_id}")
+    print(f"  Tokens:  {usage.get('prompt_tokens', '?')} in / {usage.get('completion_tokens', '?')} out")
+    print(f"  Content: {text[:200]}")
+
+    # Write results
+    result = {
+        "status": "PASS",
+        "model": model_id,
+        "elapsed_s": round(elapsed, 2),
+        "content": text,
+        "usage": usage,
+    }
+    out_path = "/tmp/smoke_nem_vl_results.json"
+    with open(out_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"\n  Results → {out_path}")
+    print("=" * 60)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    run_smoke()


### PR DESCRIPTION
## Summary

This PR adds a single Claude Code skill, `/byo-video`, plus its nine helper scripts. The skill turns "bring your own video" model exploration into a guided flow: a contributor invokes `/byo-video` in their Claude Code session, answers a few picker questions (backend, model, environment), and ends up with a live Gradio web UI where they can upload a video or image, pick a prompt, and inspect model output. The goal is to lower the floor for trying a Cosmos Reason2, Cosmos3, Nemotron-Nano-VL, or Qwen3-VL model on real footage from minutes of CLI wrangling to a single slash command.

## What's new

- One slash command (`/byo-video`) that drives the entire flow end to end with no prior shell setup beyond a GPU host or cloud account
- Phase 0 to 1 picker via `AskUserQuestion`: backend (HF Transformers, vLLM, NIM-local Docker), model family (Cosmos Reason2, Cosmos3, Nemotron-Nano-VL, Qwen3-VL, or "Something else"), environment (Brev cloud GPU, SSH host, or local machine)
- Phase 2 to 6 observer subagent that provisions or restarts the GPU, deploys the helper scripts, launches `byo_video_setup.py`, tails the setup log, and reports back when Gradio is live
- Three inference backends supported in one skill: HF Transformers (simplest, slowest), vLLM (fast, quantization-aware), NIM-local (Docker container from `nvcr.io`, OpenAI-compatible API on port 8000)
- Gradio UI with video and image upload, prompt presets, and a collapsible reasoning panel that surfaces the `<think>` trace for Cosmos Reason2 outputs
- Runtime monitor that watches the live Gradio for CUDA OOM, vLLM disconnect, NIM container exit, and generic Python tracebacks, and surfaces them as actionable alerts in the Claude Code session
- Deploy monitor (`cosmos_deploy_monitor.py`) that tracks per-phase setup timing, detects tracebacks during install, and validates the HF token for gated models before download starts
- NIM catalog and launch helper with the current Cosmos and Nemotron containers, including image tags, health-check routes, and port defaults
- Smoke tests for both Cosmos Reason2 and Nemotron-Nano-VL, runnable independently of the full skill flow

## Files changed (10)

- `.claude/SKILLS.md`
- `.claude/commands/byo-video.md`
- `.claude/scripts/byo_video_runtime_monitor.py`
- `.claude/scripts/byo_video_setup.py`
- `.claude/scripts/cosmos_deploy_monitor.py`
- `.claude/scripts/gradio_cr2_byo.py`
- `.claude/scripts/nim_catalog.py`
- `.claude/scripts/nim_launch.sh`
- `.claude/scripts/smoke_cr2_byo.py`
- `.claude/scripts/smoke_nem_vl.py`


## How to try this locally

1. `cd cosmos-cookbook`
2. Install Claude Code if you don't already have it (`npm i -g @anthropic-ai/claude-code` or follow the official install docs), then run `claude` from the repo root so the `.claude/` directory is picked up.
3. In the Claude Code session, invoke `/byo-video`.
4. For the simplest path, pick **HF Transformers** as the backend, **Cosmos Reason2 2B** as the model, and **Local machine** as the environment. This avoids cloud provisioning and Docker entirely.
5. Wait roughly 10 minutes for first-time setup (model download dominates) and roughly 30 seconds for the first inference once Gradio reports ready. The skill will print both the local URL and a `gradio.live` public URL.

## Test plan checklist

- [ ] `/byo-video` fires the backend / model / environment picker without error
- [ ] `byo_video_setup.py` runs to completion and the setup log reaches a "Gradio live" line
- [ ] Both the local URL and the `gradio.live` URL load the UI
- [ ] Uploading a short clip and submitting the default prompt returns non-empty text within a reasonable budget for the chosen backend
- [ ] For a Cosmos Reason2 model, the collapsible reasoning panel renders a `<think>` trace above the final answer
- [ ] The runtime monitor shows no alerts after roughly 5 minutes of idle plus a few inferences
- [ ] The runtime monitor surfaces a clear alert if the inference process is killed mid-session (e.g., `kill -9` the vLLM or NIM process and confirm the alert fires)
- [ ] `smoke_cr2_byo.py` and `smoke_nem_vl.py` both pass on a machine that has the relevant model cached

## Known limitations

- Frame extraction caps at 5 frames per request when sent to a NIM container. Uniform distribution across clip duration mitigates this for longer videos but it is still a hard cap on the NIM path.
- The NIM 32B image is allowlist-gated on NGC. The 2B, 8B, and Reason1-7B images work without an allowlist and are the recommended starting points.
- The `gradio.live` tunnel can fail when the upstream relay is overloaded. The local URL always works as a fallback and is printed alongside the public one.
- The FP8-quantized 8B NIM has a known greedy-decode `<think>` plus EOS bug that can produce 1 to 3 token responses. The skill defaults temperature to 0.6 in `nim_local` mode, and the runtime monitor flags suspiciously short responses so reviewers can spot the failure mode quickly.

## Footnote

Verified end-to-end on RTX PRO 6000 Blackwell Server Edition with the cosmos-reason2-2b NIM container; runtime monitor logged 9+ inferences with no error alerts.
