### PR TITLE
fix(examples): guard against empty choices and message=None in LLM calls

### DIFF
--- a/docs/getting_started/nebius/reason2/src/cosmos_reason2_tests.py
+++ b/docs/getting_started/nebius/reason2/src/cosmos_reason2_tests.py
@@ -347,6 +347,8 @@ def run_test(
             extra_body=extra_body if extra_body else None,
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         result = response.choices[0].message.content
 
         print(f"\n{'-' * 70}")

--- a/scripts/examples/reason1/av_video_caption_vqa/model_openai.py
+++ b/scripts/examples/reason1/av_video_caption_vqa/model_openai.py
@@ -91,6 +91,8 @@ class OpenAIModel:
                 print(f"Retrying... count = {retry_count}.")
                 time.sleep(10)
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         response_text = response.choices[0].message.content
         return response_text
 

--- a/scripts/examples/reason1/temporal_localization/process_video_openai_api.py
+++ b/scripts/examples/reason1/temporal_localization/process_video_openai_api.py
@@ -122,6 +122,8 @@ def process_video(client, video_path, model_name, max_tokens, user_prompt):
     )
     latency = time.time() - t0
 
+    if not resp.choices or resp.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return resp.choices[0].message.content, latency
 
 


### PR DESCRIPTION
## What

Add explicit guards at three LLM call sites in example scripts before accessing `response.choices[0].message.content`.

## Why

`client.chat.completions.create()` can return two empty-response shapes:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures  
2. **`choices[0].message = None`** — e.g. Gemini 2.5 Flash (via OpenAI-compatible endpoint) returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None`

Both crash with `IndexError` or `AttributeError`.

## Files changed

| File | Fix |
|------|-----|
| `docs/getting_started/nebius/reason2/src/cosmos_reason2_tests.py` | Guard before `response.choices[0].message.content` |
| `scripts/examples/reason1/av_video_caption_vqa/model_openai.py` | Guard before `response.choices[0].message.content` |
| `scripts/examples/reason1/temporal_localization/process_video_openai_api.py` | Guard before `resp.choices[0].message.content` |

```python
# Before
result = response.choices[0].message.content

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
result = response.choices[0].message.content
```

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.8k violations in 800+ repos.